### PR TITLE
Add glob pattern matching support to the "opt_include" directive.

### DIFF
--- a/conf/kismet.conf.in
+++ b/conf/kismet.conf.in
@@ -7,7 +7,8 @@
 version=2017
 
 # Include optional site-local config options.  If this config file is not
-# present, it will be ignored.
+# present, it will be ignored. The option also supports glob pattern matching 
+# for specifying sets of filenames.
 opt_include=%E/kismet_site.conf
 
 # Include the httpd config options

--- a/configfile.h
+++ b/configfile.h
@@ -74,6 +74,7 @@ protected:
 
     // Internal non-locking versions for use when parsing configs ourselves
     int ParseConfig_nl(const char *in_fname);
+    void ParseOptInclude(const string path);
     string ExpandLogPath_nl(string path, string logname, string type, 
             int start, int overwrite = 0);
 

--- a/configure
+++ b/configure
@@ -5673,6 +5673,18 @@ fi
 
 done
 
+for ac_header in glob.h
+do :
+  ac_fn_cxx_check_header_mongrel "$LINENO" "glob.h" "ac_cv_header_glob_h" "$ac_includes_default"
+if test "x$ac_cv_header_glob_h" = xyes; then :
+  cat >>confdefs.h <<_ACEOF
+#define HAVE_GLOB_H 1
+_ACEOF
+
+fi
+
+done
+
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for dwarf_begin in -ldw" >&5
 $as_echo_n "checking for dwarf_begin in -ldw... " >&6; }

--- a/configure.ac
+++ b/configure.ac
@@ -228,6 +228,7 @@ AC_CHECK_HEADERS([errno.h stdlib.h string.h sys/socket.h sys/time.h sys/wait.h u
 	AC_MSG_ERROR(Missing required system header))
 
 AC_CHECK_HEADERS([getopt.h])
+AC_CHECK_HEADERS([glob.h])
 
 AC_CHECK_LIB([dw], [dwarf_begin], HAVE_LIBDW=1)
 AC_CHECK_LIB([bfd], [bfd_alloc], HAVE_LIBBFD=1)


### PR DESCRIPTION
This change provides glob pattern matching support to the value specified for the "opt_include" directive.

The intent of this change is to allow for dynamically extending the Kismet configuration without modifying the primary kistmet.conf. This can be useful for injecting settings from optional plug-ins by specifying an a single include path with wildcard matching; for example: opt_include=/usr/local/etc/kismet.d/*.conf