### PR TITLE
Fix installing kismet_cap_hackrf_sweep

### DIFF
--- a/capture_hackrf_sweep.c
+++ b/capture_hackrf_sweep.c
@@ -62,7 +62,7 @@
 #include "capture_framework.h"
 
 
-#ifndef BUILD_HACKRF_SWEEP
+#ifndef BUILD_CAPTURE_HACKRF_SWEEP
 
 /* If the required libraries (hackrf and fftw3) are not available, build the 
  * capture binary, but only return errors.
@@ -315,7 +315,7 @@ int open_callback(kis_capture_handler_t *caph, uint32_t seqno, char *definition,
         cf_params_interface_t **ret_interface,
         cf_params_spectrum_t **ret_spectrum) {
 
-
+    return 0;
 }
 
 int list_callback(kis_capture_handler_t *caph, uint32_t seqno,

--- a/config.h.in
+++ b/config.h.in
@@ -22,7 +22,7 @@
 #undef BIN_LOC
 
 /* Able to build hackrf sweep source */
-#undef BUILD_HACKRF_SWEEP
+#undef BUILD_CAPTURE_HACKRF_SWEEP
 
 /* system data directory */
 #undef DATA_LOC

--- a/configure
+++ b/configure
@@ -5713,7 +5713,7 @@ HAVE_LIBHACKRF=0
 HAVE_LIBFFTW3=0
 HAVE_HACKRF_H=0
 HAVE_FFTW3_H=0
-BUILD_HACKRF_SWEEP=0
+BUILD_CAPTURE_HACKRF_SWEEP=0
 HACKRF_MISSING_REASON="Missing required libhack/libfftw3 libraries"
 
 for ac_header in libhackrf/hackrf.h
@@ -5869,9 +5869,9 @@ rm -f core conftest.err conftest.$ac_objext \
     conftest$ac_exeext conftest.$ac_ext
     if test "$hackrfsweep" -eq 1; then
 
-$as_echo "#define BUILD_HACKRF_SWEEP 1" >>confdefs.h
+$as_echo "#define BUILD_CAPTURE_HACKRF_SWEEP 1" >>confdefs.h
 
-        BUILD_HACKRF_SWEEP=1
+        BUILD_CAPTURE_HACKRF_SWEEP=1
         DATASOURCE_BINS="$DATASOURCE_BINS \$(CAPTURE_HACKRF_SWEEP)"
     else
         { $as_echo "$as_me:${as_lineno-$LINENO}: WARNING: Old version of libhack does not contain sweep code" >&5
@@ -11590,7 +11590,7 @@ else
 fi
 
 printf "       HackRF spectrum: "
-if test "$BUILD_HACKRF_SWEEP" -eq 1; then
+if test "$BUILD_CAPTURE_HACKRF_SWEEP" -eq 1; then
 	echo "yes (libhackrf and libfftw3 present)";
 else
 	echo "no ($HACKRF_MISSING_REASON)";

--- a/configure.ac
+++ b/configure.ac
@@ -233,7 +233,7 @@ HAVE_LIBHACKRF=0
 HAVE_LIBFFTW3=0
 HAVE_HACKRF_H=0
 HAVE_FFTW3_H=0
-BUILD_HACKRF_SWEEP=0
+BUILD_CAPTURE_HACKRF_SWEEP=0
 HACKRF_MISSING_REASON="Missing required libhack/libfftw3 libraries"
 
 AC_CHECK_HEADERS([libhackrf/hackrf.h],
@@ -267,8 +267,8 @@ if test "$HAVE_LIBHACKRF" -eq 1 && test "$HAVE_LIBFFTW3" -eq 1; then
     		return 0;
     		]])],[hackrfsweep=1],[hackrfsweep=0])
     if test "$hackrfsweep" -eq 1; then
-        AC_DEFINE(BUILD_HACKRF_SWEEP, 1, Able to build hackrf sweep source)
-        BUILD_HACKRF_SWEEP=1
+        AC_DEFINE(BUILD_CAPTURE_HACKRF_SWEEP, 1, Able to build hackrf sweep source)
+        BUILD_CAPTURE_HACKRF_SWEEP=1
         DATASOURCE_BINS="$DATASOURCE_BINS \$(CAPTURE_HACKRF_SWEEP)"
     else
         AC_MSG_WARN([Old version of libhack does not contain sweep code])
@@ -1398,7 +1398,7 @@ else
 fi
 
 printf "       HackRF spectrum: "
-if test "$BUILD_HACKRF_SWEEP" -eq 1; then
+if test "$BUILD_CAPTURE_HACKRF_SWEEP" -eq 1; then
 	echo "yes (libhackrf and libfftw3 present)";
 else
 	echo "no ($HACKRF_MISSING_REASON)";


### PR DESCRIPTION
The mixture of autotools definitions made hackrf capture utility
compiled, but not installed. This patch unify them and use
`BUILD_CAPTURE_HACKRF_SWEEP` everywhere