### PR TITLE
Fix handshake PCAP download URL

### DIFF
--- a/docs/dev/webui_rest.md
+++ b/docs/dev/webui_rest.md
@@ -706,11 +706,11 @@ To match on a single explicit SSID or any ssid ending in 'foo':
 }
 ```
 
-##### /phy/phy80211/by-bssid/[MAC]/pcap/[MAC]-handshake.pcap 
+##### /phy/phy80211/by-key/[key]/pcap/[key]-handshake.pcap
 
 *LOGIN REQUIRED*
 
-Retrieve a pcap file of WPA EAPOL key packets seen by the 802.11 access point with the BSSID `[MAC]`.  If there are no WPA handshake packets, an empty pcap file will be returned.
+Retrieve a pcap file of WPA EAPOL key packets seen by the 802.11 access point specified by `[key]`.  If there are no WPA handshake packets, an empty pcap file will be returned.
 
 This pcap file is not streamed, it is a single pcap of the handshake packets only.
 

--- a/http_data/js/kismet.ui.dot11.js
+++ b/http_data/js/kismet.ui.dot11.js
@@ -329,10 +329,9 @@ kismet_ui.AddDeviceDetail("dot11", "Wi-Fi (802.11)", 0, {
                             warning = '<br><i style="color: red;">While handshake packets have been seen, no complete handshakes collected.</i>';
                         }
 
-                        var mac = opts['data']['kismet.device.base.macaddr'];
                         var key = opts['data']['kismet.device.base.key'];
                         var url = '<a href="/phy/phy80211/by-key/' + key + '/pcap/' +
-                            mac + '-handshake.pcap">' +
+                            key + '-handshake.pcap">' +
                             '<i class="fa fa-download"></i> Download Pcap File</a>' +
                             warning;
                         return url;


### PR DESCRIPTION
After migrating device keys in a3246214b, the download URL for handshake PCAPs needs to be adjusted to use the new key as part of the filename instead of the MAC address.

I also updated the documentation for the corresponding REST endpoint.