### PR TITLE
Fixed typo in CryptToHumanReadable function where it failed to ref

### DIFF
--- a/http_data/js/kismet.ui.dot11.js
+++ b/http_data/js/kismet.ui.dot11.js
@@ -118,7 +118,7 @@ exports.CryptToHumanReadable = function(cryptset) {
     if (cryptset & exports.crypt_unknown_protected)
         ret.push("Unknown");
 
-    if (cryptset & exports.crypt_unkown_nonwep)
+    if (cryptset & exports.crypt_unknown_nonwep)
         ret.push("Unknown-Non-WEP");
 
     return ret.join(" ");


### PR DESCRIPTION
Fixed typo in CryptToHumanReadable function where it failed to reference crypt_unknown_nonwep correctly.