### PR TITLE
fixing curl command for automake-perl patch

### DIFF
--- a/docs/howto/pineapple-tetra.md
+++ b/docs/howto/pineapple-tetra.md
@@ -69,7 +69,7 @@ index 32c4adabb7..93aae75756 100644
 You'll also need to patch against a bug in the old OpenWRT code triggered by a modern perl version:
 
 ```
-$ curl 'https://git.lede-project.org/?p=openwrt/openwrt.git;a=blob_plain;f=tools/automake/patches/010-automake-port-to-Perl-5.22-and-later.patch;h=31b9273d547145e5ecbeaef20a1e82cc9292fdc2;hb=92c80f38cff3c20388f9ac13d5196f2745aeaf77' > tools/automake/patches/010-automake-perl.patch
+$ curl 'https://git.openwrt.org/?p=openwrt/openwrt.git;a=blob_plain;f=tools/automake/patches/010-automake-port-to-Perl-5.22-and-later.patch;h=31b9273d547145e5ecbeaef20a1e82cc9292fdc2;hb=92c80f38cff3c20388f9ac13d5196f2745aeaf77' > tools/automake/patches/010-automake-perl.patch
 ```
 
 ## Tweak packet.mk


### PR DESCRIPTION
The curl command for applying the automake-perl patch was not working anymore. Since the openwrt-lede.org domain moved to openwrt.org, the patch file was containing the `301 moved permanetly` message of the webserver instead of the patch.
The result was the following error message while trying to build:
```
...
patch: **** Only garbage was found in the patch input.
...
```