### PR TITLE
Use self-chosen name if_name of IDB

### DIFF
--- a/pcapng_stream_ringbuf.cc
+++ b/pcapng_stream_ringbuf.cc
@@ -174,12 +174,9 @@ int Pcap_Stream_Ringbuf::pcapng_make_shb(std::string in_hw, std::string in_os, s
 }
 
 int Pcap_Stream_Ringbuf::pcapng_make_idb(KisDatasource *in_datasource) {
+    
     std::string ifname;
-    if (in_datasource->get_source_cap_interface().length() > 0) {
-        ifname = in_datasource->get_source_cap_interface();
-    } else {
-        ifname = in_datasource->get_source_interface();
-    }
+    ifname = in_datasource->get_source_name();
 
     std::string ifdesc;
     if (in_datasource->get_source_cap_interface() !=


### PR DESCRIPTION
Imho this PR does not change the actual behaviour* except that if the user choose a name for the interface like:

```
kismet_cap_linux_wifi --connect localhost:3501 --source=wlan0:name=explicitAPname
```
In this case the self-chosen name will get included in the if_name field of IDB in pcap-ng file as well.

I think everyone who wants to gave a name to a device explicitly wants to see it in the pcap-ng file as well, therefore I hope you'll inlcude this PR :-)

Let me know, if anything is unclear.

&ast; please note that get_source_name() is the same as get_source_cap_interface() if length > 0 or it is get_source_interface(). Therefore, I deleted the if-else-clause.