### PR TITLE
Fix hop rate in Python module

### DIFF
--- a/python_modules/KismetRest/KismetRest/__init__.py
+++ b/python_modules/KismetRest/KismetRest/__init__.py
@@ -636,7 +636,7 @@ class KismetConnector:
         """
 
         cmd = {
-            "hoprate": rate
+            "rate": rate
         }
 
         (r, v) = self.__post_string_url("datasource/by-uuid/{}/set_channel.cmd".format(uuid), cmd)
@@ -654,7 +654,7 @@ class KismetConnector:
         """
 
         cmd = {
-            "hoprate": rate,
+            "rate": rate,
             "channels": channels
         }
 


### PR DESCRIPTION
I tried to use config_datasource_set_hop_rate and got the response `expected channel, channels, or rate`, so this PR corrects it.