### PR TITLE
Add list_interfaces API to KismetConnector

### DIFF
--- a/python_modules/KismetRest/KismetRest/__init__.py
+++ b/python_modules/KismetRest/KismetRest/__init__.py
@@ -606,6 +606,16 @@ class KismetConnector:
         (r, v) = self.__get_json_url("datasource/all_sources.json", stream=False)
 
         return v[0]
+        
+    def datasource_list_interfaces(self):
+        """
+        datasource_list_interfaces() -> Interfaces list
+        
+        Return list of all available interfaces
+        """
+        (r, v) = self.__get_json_url("datasource/list_interfaces.json", stream=False)
+        
+        return v[0]
 
     def config_datasource_set_channel(self, uuid, channel):
         """

--- a/rest_examples/datasource_add_source.py
+++ b/rest_examples/datasource_add_source.py
@@ -13,6 +13,7 @@ parser.add_argument('--uri', action="store", dest="uri")
 parser.add_argument('--user', action="store", dest="user")
 parser.add_argument('--passwd', action="store", dest="passwd")
 parser.add_argument('--source', action="store", dest="source")
+parser.add_argument('--list-available', action="store_true", dest="list_available")
 
 results = parser.parse_args()
 
@@ -22,24 +23,39 @@ if results.user != None:
     user = results.user
 if results.passwd != None:
     passwd = results.passwd
-if results.source == None:
-    print "Requires --source option"
+if results.source == None and not results.list_available:
+    print("Requires --source option")
     sys.exit(1);
 
 kr = KismetRest.KismetConnector(uri)
 kr.set_login(user, passwd)
 kr.set_debug(True)
 
+if results.list_available:
+    interfaces = kr.datasource_list_interfaces()
+    for interface in interfaces:
+        if interface['kismet.datasource.probed.in_use_uuid'] == '00000000-0000-0000-0000-000000000000':
+            in_use = False
+        else:
+            in_use = True
+        print("%s (%s, %s) - %sin use" % (
+            interface['kismet.datasource.probed.interface'],
+            interface['kismet.datasource.probed.hardware'],
+            interface['kismet.datasource.type_driver']['kismet.datasource.driver.type'],
+            "not " if not in_use else ''
+        ))
+    sys.exit()
+
 if not kr.check_session():
-    print "Invalid login, specify --user and --password if you have changed your "
-    print "default Kismet config (which you should do)"
+    print("Invalid login, specify --user and --password if you have changed your ")
+    print("default Kismet config (which you should do)")
     sys.exit(1)
 
 print("adding src ", results.source)
 r = kr.add_datasource(results.source)
 
 if r:
-    print "Source added successfully"
+    print("Source added successfully")
 else:
-    print "Error adding source - check Kismet messages"
+    print("Error adding source - check Kismet messages")
 


### PR DESCRIPTION
This lets us use list_interfaces in Python and extends the recently added `datasource_add_source.py`.

Example:
```
$ python3 datasource_add_source.py --user kismet --passwd removed --list-available
wlan5 (rt2800usb, linuxwifi) - not in use
$ python3 datasource_add_source.py --user kismet --passwd removed --source wlan5
adding src  wlan5
Source added successfully
$ python3 datasource_add_source.py --user kismet --passwd removed --list-available
wlan5 (rt2800usb, linuxwifi) - in use
wlan5mon (rt2800usb, linuxwifi) - in use
```
