### PR TITLE
Fixed sth. confused

### DIFF
--- a/docs/dev/webui_rest.md
+++ b/docs/dev/webui_rest.md
@@ -166,22 +166,22 @@ Field specification objects take the format of a vector/array containing multipl
 where a field may be a single element string, defining a field name or a field path, such as:
 
 * `'kismet.device.base.channel'`
-* `'kismet.device.base.signal/kismet.common.signal.last_signal_dbm'`
+* `'kismet.device.base.signal/kismet.common.signal.last_signal'`
 
 *or* a field may be a two-element array, consisting of a field name or path, and a target name the field will be aliased as, for example:
 
-* `[kismet.device.base.channel', 'base.channel']`
-* `[kismet.device.base.signal/kismet.common.signal.last_signal_dbm', 'base.last.signal']`
+* `['kismet.device.base.channel', 'base.channel']`
+* `['kismet.device.base.signal/kismet.common.signal.last_signal', 'base.last.signal']`
 
 Fields will be returned in the device as their final path name:  that is, from the above example, the device would contain:
 
-`['kismet.device.base.channel', 'kismet.common.signal.last_signal_dbm']`
+`['kismet.device.base.channel', 'kismet.common.signal.last_signal']`
 
 And from the second example, it would contain:
 
 `['base.channel', 'base.last.signal']`
 
-When requesting multiple fields from different paths with the same name - for instance, multiple signal paths provide the `kismet.common.signal.last_signal_dbm` - it is important to provide an alias.  Fields which resolve to the same name will only be present in the results once, and the order is undefined.
+When requesting multiple fields from different paths with the same name - for instance, multiple signal paths provide the `kismet.common.signal.last_signal` - it is important to provide an alias.  Fields which resolve to the same name will only be present in the results once, and the order is undefined.
 
 ### Filter Specifications
 


### PR DESCRIPTION
In your doc 'webui_rest.md', the field 'kismet.common.signal.last_signal_dbm' is not existed in kismet release 2018-08, causing the **aliase** not working, which will make developers confused. I changed the field into an existing one, and it works. Please check it, thx.