### PR TITLE
Fix issues with TypeErrors in log_tools

### DIFF
--- a/log_tools/elk/kismet_log_to_elk.py
+++ b/log_tools/elk/kismet_log_to_elk.py
@@ -83,7 +83,7 @@ c = db.cursor()
 
 for row in c.execute(sql):
     try:
-        dev = strip_old_empty_trees(json.loads(row[0]))
+        dev = strip_old_empty_trees(json.loads(str(row[0])))
         dev = rename_json_keys(dev)
         res = es.index(index='kismet', doc_type='device', body=dev)
         print dev['kismet_device_base_key'], res

--- a/log_tools/kismet_log_devices_to_json.py
+++ b/log_tools/kismet_log_devices_to_json.py
@@ -83,7 +83,7 @@ c = db.cursor()
 devs = []
 
 for row in c.execute(sql, replacements):
-    devs.append(json.loads(row[0]))
+    devs.append(json.loads(str(row[0])))
 
 if results.outfile:
     logf = open(results.outfile, "w")

--- a/log_tools/kismet_log_to_kml.py
+++ b/log_tools/kismet_log_to_kml.py
@@ -100,7 +100,7 @@ num_plotted = 0
 
 for row in c.execute(sql, replacements):
     try:
-        dev = json.loads(row[0])
+        dev = json.loads(str(row[0]))
 
         # Check for the SSID if we're doing that; allow it to trip
         # a KeyError and jump out of processing this device


### PR DESCRIPTION
I suspect that when porting back to python 2, something was missed, as DB rows were being returned as objects, and not strings that the json module could interpret.