### PR TITLE
freaky fixes

### DIFF
--- a/capture_freaklabs_zigbee/KismetCaptureFreaklabsZigbee/__init__.py
+++ b/capture_freaklabs_zigbee/KismetCaptureFreaklabsZigbee/__init__.py
@@ -79,6 +79,7 @@ class SerialInputHandler(object):
     def __init__(self, port, baudrate):
         self.__sensniff_magic_legacy = struct.pack('BBBB', 0x53, 0x6E, 0x69, 0x66)
         self.__sensniff_magic = struct.pack('BBBB', 0xC1, 0x1F, 0xFE, 0x72)
+        self._current_channel = -1
 
         try:
             self.port = serial.Serial(port = port,
@@ -165,12 +166,8 @@ class SerialInputHandler(object):
 
         # If we reach here, we have a command response
         b = bytearray(b)
-        # if cmd == CMD_CHANNEL:
-        #     # We'll only ever see this if the user asked for it, so we are
-        #     # running interactive. Print away
-        #     print 'Sniffing in channel: %d' % (b[0],)
-        # else:
-        #     logger.warn("Received a command response with unknown code")
+        if cmd == CMD_CHANNEL:
+             self._current_channel = b[0]
         return ''
 
     def __write_command(self, cmd):
@@ -181,6 +178,10 @@ class SerialInputHandler(object):
 
     def set_channel(self, channel):
         self.__write_command(bytearray([CMD_SET_CHANNEL, 1, channel]))
+        # this hardware takes 150ms for PLL lock, full stop
+        time.sleep (0.15)
+        if ((channel != self._current_channel) and (self._current_channel != -1)):
+            raise FreaklabException
 
     def get_channel(self):
         self.__write_command(bytearray([CMD_GET_CHANNEL]))
@@ -231,7 +232,7 @@ class KismetFreaklabsZigbee(object):
 
         self.defaults['device'] = "/dev/ttyUSB0"
         self.defaults['baudrate'] = "57600"
-        self.defaults['band'] = "900"
+        self.defaults['band'] = "2400"
         self.defaults['name'] = None
 
         self.hop_thread = None
@@ -243,7 +244,7 @@ class KismetFreaklabsZigbee(object):
         self.chan_config['hopping'] = True
         self.chan_config['channel'] = "0"
         self.chan_config['hop_channels'] = []
-        self.chan_config['hop_rate'] = 5
+        self.chan_config['hop_rate'] = 1
         self.chan_config['chan_skip'] = 0
         self.chan_config['chan_offset'] = 0
 
@@ -316,7 +317,7 @@ class KismetFreaklabsZigbee(object):
 
                 try:
                     self.chan_config_lock.acquire()
-                    c = self.chan_config['chan_pos'] % len(self.chan_config['hop_channels'])
+                    c = int(self.chan_config['hop_channels'][self.chan_config['chan_pos'] % len(self.chan_config['hop_channels'])])
                     self.serialhandler.set_channel(c)
                 except FreaklabException as e:
                     self.kismet.send_error_report(message = "Could not tune to {}: {}".format(self.chan_config['chan_pos'], e))


### PR DESCRIPTION
This does a few things, in order of simple to not:

Set default band to 2400, where most zigbee actually seems to be

Set default hop rate to 1 per second.  The hardware takes 150ms for PLL lock, so at 5/s you are spending three times as much time hopping as sniffing

Fix hopping in 2.4GHz.  This was probably testing on 900MHz where it worked and missed on 2.4 due to the lack of error detection.  The channel to hop on was actually the index itself, so 2.4 ghz was hopping on channel 0-15 instead of 11-26

Added a variable on SerialInputHandler to read in the currently set channel as it hops and compare it to the channel we thought we were setting to ensure things work.  This should actually work to detect issues for all hardware before and after my firmware fixes, although I suspect 900MHz doesn't work without my firmware fixes (PR open upstream already)