### PR TITLE
updating date stamp format to fix issue detected on WiGLE forums - 'Mar' -> '03'

### DIFF
--- a/log_tools/kismetdb_to_wiglecsv.cc
+++ b/log_tools/kismetdb_to_wiglecsv.cc
@@ -538,7 +538,7 @@ int main(int argc, char *argv[]) {
                 std::tm tm = *std::localtime(&timet);
                 std::stringstream ts;
 
-                ts << std::put_time(&tm, "%Y-%b-%d %H:%M:%S"); 
+                ts << std::put_time(&tm, "%Y-%m-%d %H:%M:%S");
 
                 cached = new cache_obj{ts.str(), name, crypt};
 


### PR DESCRIPTION
proposed fix for #122 
happy to be schooled on the vagaries of std::put_time formatting / localization.