### PR TITLE
Fixed typo:  priorty

### DIFF
--- a/http_data/index.html
+++ b/http_data/index.html
@@ -165,7 +165,7 @@ $(function() {
 
     kismet_ui_iconbar.AddIconbarItem({
         id: 'gps',
-        priorty: 110,
+        priority: 110,
         createCallback: function(div) {
             div.gps();
         }

--- a/http_data/js/kismet.ui.js
+++ b/http_data/js/kismet.ui.js
@@ -171,7 +171,7 @@ exports.AddDeviceRowHighlight = function(options) {
     DeviceRowHighlights.sort(function(a, b) {
         if (a.priority < b.priority)
             return -1;
-        if (b.priority > a.priorty)
+        if (b.priority > a.priority)
             return 1;
 
         return 0;


### PR DESCRIPTION
Corrected two instances where "priority' was misspelled 'priorty'.