### PR TITLE
Docker: Include libusb-1.0 package, fix run command

### DIFF
--- a/packaging/docker/Dockerfile
+++ b/packaging/docker/Dockerfile
@@ -9,7 +9,7 @@ RUN apt-get update && \
     libcap-dev libpcap-dev libncurses5-dev libnm-dev libdw-dev \
     libsqlite3-dev libprotobuf-dev libprotobuf-c-dev \
     protobuf-compiler protobuf-c-compiler \
-    librtlsdr0 
+    librtlsdr0 libusb-1.0
 
 COPY build-kismet.sh /opt/build-kismet.sh
 RUN /bin/bash /opt/build-kismet.sh

--- a/packaging/docker/README
+++ b/packaging/docker/README
@@ -32,7 +32,7 @@
     
         $ docker create -p 2501:2501 -p 3501:3501 --name kismet --privileged kismet-git
         $ docker cp custom_kismet_site.conf kismet:/usr/local/etc/kismet_site.conf
-        $ docker run kismet
+        $ docker run kismet-git
     
     You can then assign interfaces to it using the included script,
     assign_wifi_to_docker.sh:


### PR DESCRIPTION
This package is required. Without this, the Docker image fails to build. And without the correct container tag, the `run` command fails.