### PR TITLE
Correct nmcli example syntax

### DIFF
--- a/kismet_server.cc
+++ b/kismet_server.cc
@@ -317,7 +317,7 @@ void SpindownKismet(std::shared_ptr<PollableTracker> pollabletracker) {
                 "         sudo service networking restart\n"
                 "         sudo /etc/init.d/networking restart\n"
                 "         or\n"
-                "         nmcli device set managed [device] true\n"
+                "         nmcli device set [device] managed true\n"
                 "\n");
 
         fprintf(stderr, "Kismet exiting.\n");


### PR DESCRIPTION
Pull request for issue #137 

From the nmcli built-in help:

Usage: nmcli device set { ARGUMENTS | help }

ARGUMENTS := DEVICE { PROPERTY [ PROPERTY ... ] }
DEVICE    := [ifname] <ifname> 
PROPERTY  := { autoconnect { yes | no } |
             { managed { yes | no }