### PR TITLE
Add libcap dependency for openwrt kismet-remote-2018

### DIFF
--- a/packaging/openwrt/kismet-remote-2018/Makefile
+++ b/packaging/openwrt/kismet-remote-2018/Makefile
@@ -17,14 +17,14 @@ PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_SOURCE_VERSION).tar.gz
 
 include $(INCLUDE_DIR)/package.mk
 
-PKG_BUILD_DEPENDS:=+libusb-compat +libpthread +libpcap +libnl-tiny +libprotobuf-c
+PKG_BUILD_DEPENDS:=+libusb-compat +libpthread +libpcap +libnl-tiny +libprotobuf-c +libcap
 
 define Package/kismet-remote
   SECTION:=net
   CATEGORY:=Network
   TITLE:=Kismet Remote Capture (2018-08-BETA1)
   URL:=https://www.kismetwireless.net/
-  DEPENDS:=+libusb-compat +libpthread +libpcap +libnl-tiny +libprotobuf-c
+  DEPENDS:=+libusb-compat +libpthread +libpcap +libnl-tiny +libprotobuf-c +libcap
 endef
 
 define Package/kismet-remote/description


### PR DESCRIPTION
The `kismet-remote-2018` package definition for OpenWRT is missing a dependency on libcap. This makes the build fail with an error about missing `libcap.so.2`.

The attached PR adds the missing dependency declarations to the Makefile.