### PR TITLE
differentiate between WIFI and Bluetooth

### DIFF
--- a/log_tools/kismetdb_to_wiglecsv.cc
+++ b/log_tools/kismetdb_to_wiglecsv.cc
@@ -556,8 +556,14 @@ int main(int argc, char *argv[]) {
         } 
         cached->last_time_sec = ts;
 
-        if (phy == "IEEE802.11")
+        auto reporttype = "";
+        if (phy == "IEEE802.11") {
             channel = FrequencyToWifiChannel(channel);
+            reporttype = "WIFI";
+        }
+        if (phy == "Bluetooth") {
+            reporttype = "BT";
+        }
 
         // printf("MAC,SSID,AuthMode,FirstSeen,Channel,RSSI,CurrentLatitude,CurrentLongitude,AltitudeMeters,AccuracyMeters,Type\n");
 
@@ -569,7 +575,7 @@ int main(int argc, char *argv[]) {
                 (int) channel,
                 signal,
                 lat, lon, alt,
-                "WIFI");
+                reporttype);
 
         n_saved++;
     }
@@ -601,4 +607,3 @@ int main(int argc, char *argv[]) {
 
     return 0;
 }
-


### PR DESCRIPTION
replace hardcoded WIFI with dynamic selection.

With this change WIFI and Bluetooth devices get correctly reported in wigle.

I tested it locally and it works, but please crosscheck, also on coding style -> first time C for me...