### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -217,6 +217,13 @@ ALL	= @ALLTARGETS@
 
 INSTBINS = $(PS) $(DATASOURCE_BINS) $(LOGTOOL_BINS)
 
+DATE_FMT = +%Y-%m-%dT%H:%M:%S
+ifdef SOURCE_DATE_EPOCH
+    BUILD_DATE ?= $(shell date -u -d "@$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u -r "$(SOURCE_DATE_EPOCH)" "$(DATE_FMT)" 2>/dev/null || date -u "$(DATE_FMT)")
+else
+    BUILD_DATE ?= $(shell date "$(DATE_FMT)")
+endif
+
 all:	$(ALL)
 
 all-with-plugins:
@@ -227,7 +234,7 @@ all-with-plugins:
 # Autogen the version file
 version.c:	FORCE
 	@{ $(GIT) rev-parse --short HEAD 2>/dev/null || echo "non-git-release"; } | awk ' BEGIN {print "#include \"version.h\""} {print "const char *VERSION_GIT_COMMIT = \"" $$0"\";"} END {}' > version.c
-	@date | awk 'BEGIN {} {print "const char *VERSION_BUILD_TIME = \""$$0"\";"} END {} ' >> version.c
+	@echo "$(BUILD_DATE)" | awk 'BEGIN {} {print "const char *VERSION_BUILD_TIME = \""$$0"\";"} END {} ' >> version.c
 
 # Force remove version.c.o since it's left behind owned by root as part of suidinstall, which screws
 # up a lot of builds for people; we assume we can `rm -f` it


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH`
in order to make builds reproducible.
See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/
for the definition of this variable.

Note: This date call is designed to work with different flavors
of date (GNU, BSD and others).
If only GNU (Linux) support is needed, the patch can be simplified.

This PR was done while working on reproducible builds for openSUSE.