### PR TITLE
ticc2531 support

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -121,6 +121,9 @@ BUILD_CAPTURE_NRF_MOUSEJACK = @BUILD_CAPTURE_NRF_MOUSEJACK@
 CAPTURE_TI_CC_2540 = capture_ti_cc_2540/kismet_cap_ti_cc_2540
 BUILD_CAPTURE_TI_CC_2540 = @BUILD_CAPTURE_TI_CC_2540@
 
+CAPTURE_TI_CC_2531 = capture_ti_cc_2531/kismet_cap_ti_cc_2531
+BUILD_CAPTURE_TI_CC_2531 = @BUILD_CAPTURE_TI_CC_2531@
+
 CAPTURE_UBERTOOTH_ONE = capture_ubertooth_one/kismet_cap_ubertooth_one
 BUILD_CAPTURE_UBERTOOTH_ONE = @BUILD_CAPTURE_UBERTOOTH_ONE@
 
@@ -129,7 +132,6 @@ BUILD_CAPTURE_NRF_51822 = @BUILD_CAPTURE_NRF_51822@
 
 CAPTURE_NXP_KW41Z = capture_nxp_kw41z/kismet_cap_nxp_kw41z
 BUILD_CAPTURE_NXP_KW41Z = @BUILD_CAPTURE_NXP_KW41Z@
-
 
 # Capture binaries to build
 DATASOURCE_BINS = @DATASOURCE_BINS@
@@ -194,8 +196,8 @@ PSO	= util.cc.o macaddr.cc.o uuid.cc.o xxhash.cc.o boost_like_hash.cc.o sqlite3_
 	$(PROTOBUF_CPP_O_TARGET) kis_external.cc.o \
 	dlttracker.cc.o antennatracker.cc.o datasourcetracker.cc.o kis_datasource.cc.o \
 	datasource_linux_bluetooth.cc.o datasource_rtl433.cc.o datasource_rtlamr.cc.o datasource_rtladsb.cc.o \
-	datasource_ti_cc_2540.cc.o datasource_ubertooth_one.cc.o datasource_nrf_51822.cc.o \
-	datasource_nxp_kw41z.cc.o \
+	datasource_ti_cc_2540.cc.o datasource_ti_cc_2531.cc.o datasource_ubertooth_one.cc.o datasource_nrf_51822.cc.o \
+	datasource_nxp_kw41z.cc.o\
 	kis_net_microhttpd.cc.o kis_net_microhttpd_handlers.cc.o system_monitor.cc.o base64.cc.o \
 	kis_httpd_websession.cc.o kis_httpd_registry.cc.o \
 	gpstracker.cc.o kis_gps.cc.o gpsnmea.cc.o gpsserial2.cc.o gpstcp.cc.o \
@@ -305,6 +307,9 @@ $(CAPTURE_NRF_MOUSEJACK): $(PROTOBUF_C_H) $(DATASOURCE_COMMON_A) FORCE
 $(CAPTURE_TI_CC_2540): $(PROTOBUF_C_H) $(DATASOURCE_COMMON_A) FORCE
 	(cd capture_ti_cc_2540 && $(MAKE))
 
+$(CAPTURE_TI_CC_2531): $(PROTOBUF_C_H) $(DATASOURCE_COMMON_A) FORCE
+	(cd capture_ti_cc_2531 && $(MAKE))
+
 $(CAPTURE_UBERTOOTH_ONE): $(PROTOBUF_C_H) $(DATASOURCE_COMMON_A) FORCE
 	(cd capture_ubertooth_one && $(MAKE))
 
@@ -345,6 +350,10 @@ binsuidinstall: $(DATASOURCE_BINS)
 
 	@if test "$(BUILD_CAPTURE_TI_CC_2540)"x = "1"x; then \
 		$(INSTALL) -o $(INSTUSR) -g $(SUIDGROUP) -m 4550 $(CAPTURE_TI_CC_2540) $(BIN)/`basename $(CAPTURE_TI_CC_2540)`; \
+	fi;
+
+	@if test "$(BUILD_CAPTURE_TI_CC_2531)"x = "1"x; then \
+		$(INSTALL) -o $(INSTUSR) -g $(SUIDGROUP) -m 4550 $(CAPTURE_TI_CC_2531) $(BIN)/`basename $(CAPTURE_TI_CC_2531)`; \
 	fi;
 
 	@if test "$(BUILD_CAPTURE_UBERTOOTH_ONE)"x = "1"x; then \
@@ -407,6 +416,10 @@ commoninstall: $(INSTBINS)
 
 	@if test "$(BUILD_CAPTURE_TI_CC_2540)"x = "1"x; then \
 		$(INSTALL) -o $(INSTUSR) -g $(INSTGRP) $(CAPTURE_TI_CC_2540) $(BIN)/`basename $(CAPTURE_TI_CC_2540)`; \
+	fi;
+
+	@if test "$(BUILD_CAPTURE_TI_CC_2531)"x = "1"x; then \
+		$(INSTALL) -o $(INSTUSR) -g $(INSTGRP) $(CAPTURE_TI_CC_2531) $(BIN)/`basename $(CAPTURE_TI_CC_2531)`; \
 	fi;
 
 	@if test "$(BUILD_CAPTURE_UBERTOOTH_ONE)"x = "1"x; then \
@@ -599,10 +612,11 @@ clean:
 	@(cd capture_sdr_rtladsb && make clean)
 	@(cd capture_nrf_mousejack && make clean)
 	@(cd capture_ti_cc_2540 && make clean)
+	@(cd capture_ti_cc_2531 && make clean)
 	@(cd capture_ubertooth_one && make clean)
 	@(cd capture_nrf_51822 && make clean)
 	@(cd capture_nxp_kw41z && make clean)
-	
+
 	@-rm -f $(DATASOURCE_COMMON_A)
 	@-rm -f protobuf_cpp/*.pb.*
 	@-rm -f protobuf_c/*.pb-c.*

--- a/capture_ti_cc_2531/Makefile.in
+++ b/capture_ti_cc_2531/Makefile.in
@@ -1,0 +1,30 @@
+include ../Makefile.inc
+
+MONITOR_OBJS = \
+	capture_ti_cc_2531.c.o 
+MONITOR_BIN = kismet_cap_ti_cc_2531
+
+all: $(MONITOR_BIN)
+
+LIBUSBCFLAGS=@LIBUSBCFLAGS@
+LIBUSBLIBS=@LIBUSBLIBS@
+
+$(MONITOR_BIN):	$(MONITOR_OBJS) $(patsubst %c.o,%c.d,$(MONITOR_OBJS)) ../libkismetdatasource.a
+		$(CCLD) $(LDFLAGS) -o $(MONITOR_BIN) $(MONITOR_OBJS) ../libkismetdatasource.a $(DATASOURCE_LIBS) $(LIBUSBLIBS)
+
+clean:
+	@-rm -f $(MONITOR_BIN)
+	@-rm -f *.o
+	@-rm -f *.d
+
+%.c.o:	%.c
+%.c.o : %.c %.c.d
+	$(CC) $(CFLAGS) $(CPPFLAGS) $(LIBUSBCFLAGS) -c $*.c -o $@
+
+%.c.d:	%.c
+	$(CC) -MM $(CFLAGS) $(CPPFLAGS) $*.c | sed -e "s/\.o/\.c.o/" > $*.c.d
+
+.PRECIOUS: %.c.d
+
+include $(wildcard $(patsubst %c.o,%c.d,$(MONITOR_OBJS)))
+

--- a/capture_ti_cc_2531/capture_ti_cc_2531.c
+++ b/capture_ti_cc_2531/capture_ti_cc_2531.c
@@ -470,7 +470,8 @@ int open_callback(kis_capture_handler_t *caph, uint32_t seqno, char *definition,
     // try pulling the channel
     if ((placeholder_len = cf_find_flag(&placeholder, "channel", definition)) > 0) {
         localchanstr = strndup(placeholder, placeholder_len);
-        localchan = atoi(localchanstr); 
+        localchan = (unsigned int *) malloc(sizeof(unsigned int));
+        *localchan = atoi(localchanstr); 
         free(localchanstr);
 
         if (localchan == NULL) {
@@ -536,7 +537,7 @@ int open_callback(kis_capture_handler_t *caph, uint32_t seqno, char *definition,
             return -1;
         }
     }
-
+    /* config */
     r = libusb_set_configuration(localticc2531->ticc2531_handle, 1);
     if (r < 0) {
         snprintf(errstr, STATUS_MAX,
@@ -566,15 +567,13 @@ int open_callback(kis_capture_handler_t *caph, uint32_t seqno, char *definition,
             return -1;
         }
     }
-   
+  
     pthread_mutex_unlock(&(localticc2531->usb_mutex));
 
     ticc2531_set_power(caph, 0x04, TICC2531_POWER_RETRIES);
-
     ticc2531_set_channel(caph, *localchan);
     
     localticc2531->channel = *localchan;
-
     ticc2531_enter_promisc_mode(caph);
 
     localticc2531->ready = true;

--- a/capture_ti_cc_2531/capture_ti_cc_2531.c
+++ b/capture_ti_cc_2531/capture_ti_cc_2531.c
@@ -1,0 +1,741 @@
+
+#include "../config.h"
+
+#include "ti_cc2531.h"
+
+#include <libusb-1.0/libusb.h>
+
+#include <stdio.h>
+#include <errno.h>
+#include <unistd.h>
+#include <stdlib.h>
+#include <stdbool.h>
+#include <string.h>
+#include <math.h>
+
+#include "../capture_framework.h"
+
+/* Unique instance data passed around by capframework */
+typedef struct {
+    libusb_context *libusb_ctx;
+    libusb_device_handle *ticc2531_handle;
+
+    unsigned int devno, busno;
+
+    pthread_mutex_t usb_mutex;
+
+    /* we don't want to do a channel query every data response, we just want to 
+     * remember the last channel used */
+    unsigned int channel;
+
+    /* keep track of our errors so we can reset if needed */
+    unsigned int error_ctr;
+
+    /* keep track of the soft resets */
+    unsigned int soft_reset;
+
+    /* flag to let use know when we are ready to capture */
+    bool ready;
+
+    kis_capture_handler_t *caph;
+} local_ticc2531_t;
+
+/* Most basic of channel definitions */
+typedef struct {
+    unsigned int channel;
+} local_channel_t;
+
+int ticc2531_set_channel(kis_capture_handler_t *caph, uint8_t channel) {
+    local_ticc2531_t *localticc2531 = (local_ticc2531_t *) caph->userdata;
+    int ret;
+    uint8_t data;
+    /* two step channel process*/
+    data = channel & 0xFF;
+    pthread_mutex_lock(&(localticc2531->usb_mutex));
+    ret = libusb_control_transfer(localticc2531->ticc2531_handle, TICC2531_DIR_OUT, TICC2531_SET_CHAN, 0x00, 0x00, &data, 1, TICC2531_TIMEOUT);
+    pthread_mutex_unlock(&(localticc2531->usb_mutex));
+
+    if (ret < 0)
+        return ret;
+
+    data = (channel >> 8) & 0xFF;
+    pthread_mutex_lock(&(localticc2531->usb_mutex));
+    ret = libusb_control_transfer(localticc2531->ticc2531_handle, TICC2531_DIR_OUT, TICC2531_SET_CHAN, 0x00, 0x01, &data, 1, TICC2531_TIMEOUT);
+    pthread_mutex_unlock(&(localticc2531->usb_mutex));
+    if (ret < 0)
+        printf("setting channel (LSB) failed!\n");
+
+    return ret;
+}
+
+int ticc2531_set_power(kis_capture_handler_t *caph,uint8_t power, int retries) {
+    int ret;
+    local_ticc2531_t *localticc2531 = (local_ticc2531_t *) caph->userdata;
+    int i;
+
+    pthread_mutex_lock(&(localticc2531->usb_mutex));
+    /* set power */
+
+    ret = libusb_control_transfer(localticc2531->ticc2531_handle, TICC2531_DIR_OUT, TICC2531_SET_POWER, 0x00, power, NULL, 0, TICC2531_TIMEOUT);
+
+    /* get power until it is the same as configured in set_power */
+    for (i = 0; i < retries; i++) {
+        uint8_t data;
+        ret = libusb_control_transfer(localticc2531->ticc2531_handle, 0xC0, TICC2531_GET_POWER, 0x00, 0x00, &data, 1, TICC2531_TIMEOUT);
+        if (ret < 0) {
+            pthread_mutex_unlock(&(localticc2531->usb_mutex));
+            return ret;
+        }
+        if (data == power) {
+            pthread_mutex_unlock(&(localticc2531->usb_mutex));
+            return 0;
+        }
+    }
+    pthread_mutex_unlock(&(localticc2531->usb_mutex));
+    return ret;
+}
+
+int ticc2531_enter_promisc_mode(kis_capture_handler_t *caph) {
+    int ret;
+    local_ticc2531_t *localticc2531 = (local_ticc2531_t *) caph->userdata;
+
+    pthread_mutex_lock(&(localticc2531->usb_mutex));
+    ret = libusb_control_transfer(localticc2531->ticc2531_handle, TICC2531_DIR_OUT, TICC2531_SET_START, 0x00, 0x00, NULL, 0, TICC2531_TIMEOUT);
+    pthread_mutex_unlock(&(localticc2531->usb_mutex));
+
+    return ret;
+}
+
+int ticc2531_exit_promisc_mode(kis_capture_handler_t *caph) {
+    int ret;
+    local_ticc2531_t *localticc2531 = (local_ticc2531_t *) caph->userdata;
+
+    pthread_mutex_lock(&(localticc2531->usb_mutex));
+    ret = libusb_control_transfer(localticc2531->ticc2531_handle, TICC2531_DIR_OUT, TICC2531_SET_END, 0x00, 0x00, NULL, 0, TICC2531_TIMEOUT);
+    pthread_mutex_unlock(&(localticc2531->usb_mutex));
+
+    return ret;
+}
+
+int ticc2531_receive_payload(kis_capture_handler_t *caph, uint8_t *rx_buf, size_t rx_max) {
+    local_ticc2531_t *localticc2531 = (local_ticc2531_t *) caph->userdata;
+    int actual_len, r;
+    
+    pthread_mutex_lock(&(localticc2531->usb_mutex));
+    r = libusb_bulk_transfer(localticc2531->ticc2531_handle, TICC2531_DATA_EP, rx_buf, rx_max, &actual_len, TICC2531_DATA_TIMEOUT);
+    pthread_mutex_unlock(&(localticc2531->usb_mutex));
+
+    if (actual_len == 4) {
+	// do this as we don't hard reset on a heartbeat then
+	// but we will try resetting the channel instead
+	localticc2531->soft_reset++;
+	if (localticc2531->soft_reset >= 2) {
+	    localticc2531->ready = false;
+	    ticc2531_exit_promisc_mode(caph);
+            ticc2531_set_channel(caph, localticc2531->channel); 
+	    ticc2531_enter_promisc_mode(caph);
+	    localticc2531->soft_reset = 0;
+	    localticc2531->ready = true;
+	}
+        return actual_len;
+    }
+
+    if (r < 0) {
+        localticc2531->error_ctr++;
+        if (localticc2531->error_ctr >= 500) {
+            return r;
+        } else {
+            /*continue on for now*/
+            return 1;
+        }
+    }
+
+    localticc2531->soft_reset = 0; /*we got something valid so reset*/    
+    localticc2531->error_ctr = 0; /*we got something valid so reset*/
+
+    return actual_len;
+}
+
+int probe_callback(kis_capture_handler_t *caph, uint32_t seqno, char *definition,
+        char *msg, char **uuid, KismetExternal__Command *frame,
+        cf_params_interface_t **ret_interface,
+        cf_params_spectrum_t **ret_spectrum) {
+ 
+    char *placeholder = NULL;
+    int placeholder_len;
+    char *interface;
+    char errstr[STATUS_MAX];
+
+    *ret_spectrum = NULL;
+    *ret_interface = cf_params_interface_new();
+
+    int x;
+    int busno = -1, devno = -1;
+
+    libusb_device **libusb_devs = NULL;
+    ssize_t libusb_devices_cnt = 0;
+    int r;
+
+    int matched_device = 0;
+
+    local_ticc2531_t *localticc2531 = (local_ticc2531_t *) caph->userdata;
+
+    if ((placeholder_len = cf_parse_interface(&placeholder, definition)) <= 0) {
+        snprintf(msg, STATUS_MAX, "Unable to find interface in definition"); 
+        return 0;
+    }
+
+    interface = strndup(placeholder, placeholder_len);
+
+    /* Look for the interface type */
+    if (strstr(interface, "ticc2531") != interface) {
+        free(interface);
+        return 0;
+    }
+
+    /* Look for interface-bus-dev */
+    x = sscanf(interface, "ticc2531-%d-%d", &busno, &devno);
+    free(interface);
+
+    /* If we don't have a valid busno/devno or malformed interface name */
+    if (x != -1 && x != 2) {
+        return 0;
+    }
+    pthread_mutex_lock(&(localticc2531->usb_mutex));
+    libusb_devices_cnt = libusb_get_device_list(localticc2531->libusb_ctx, &libusb_devs);
+
+    if (libusb_devices_cnt < 0) {
+        return 0;
+    }
+
+    for (ssize_t i = 0; i < libusb_devices_cnt; i++) {
+        struct libusb_device_descriptor dev;
+
+        r = libusb_get_device_descriptor(libusb_devs[i], &dev);
+
+        if (r < 0) {
+            continue;
+        }
+
+        if (dev.idVendor == TICC2531_USB_VENDOR && dev.idProduct == TICC2531_USB_PRODUCT) {
+            if (busno >= 0) {
+                if (busno == libusb_get_bus_number(libusb_devs[i]) &&
+                        devno == libusb_get_device_address(libusb_devs[i])) {
+                    matched_device = 1;
+                    break;
+                }
+            } else {
+                matched_device = 1;
+                busno = libusb_get_bus_number(libusb_devs[i]);
+                devno = libusb_get_device_address(libusb_devs[i]);
+                break;
+            }
+        }
+    }
+    libusb_free_device_list(libusb_devs, 1);
+    pthread_mutex_unlock(&(localticc2531->usb_mutex));
+
+    /* Make a spoofed, but consistent, UUID based on the adler32 of the interface name 
+     * and the location in the bus */
+    if ((placeholder_len = cf_find_flag(&placeholder, "uuid", definition)) > 0) {
+        *uuid = strndup(placeholder, placeholder_len);
+    } else {
+        snprintf(errstr, STATUS_MAX, "%08X-0000-0000-0000-%06X%06X",
+                adler32_csum((unsigned char *) "kismet_cap_ti_cc2531", 
+                    strlen("kismet_cap_ti_cc2531")) & 0xFFFFFFFF,
+                busno, devno);
+        *uuid = strdup(errstr);
+    }
+
+    /* TI CC 2531 supports 11-26 */
+    (*ret_interface)->channels = (char **) malloc(sizeof(char *) * 16);
+    for (int i = 11; i < 27; i++) {
+        char chstr[4];
+        snprintf(chstr, 4, "%d", i);
+        (*ret_interface)->channels[i - 11] = strdup(chstr);
+    }
+
+    (*ret_interface)->channels_len = 16;
+    
+    return 1;
+}
+
+int list_callback(kis_capture_handler_t *caph, uint32_t seqno, char *msg,
+                  cf_params_list_interface_t ***interfaces) {
+    /* Basic list of devices */
+    typedef struct ticc2531_list {
+        char *device;
+        struct ticc2531_list *next;
+    } ticc2531_list_t;
+
+    ticc2531_list_t *devs = NULL;
+    size_t num_devs = 0;
+    libusb_device **libusb_devs = NULL;
+    ssize_t libusb_devices_cnt = 0;
+    int r;
+    char devname[32];
+    unsigned int i;
+
+    local_ticc2531_t *localticc2531 = (local_ticc2531_t *) caph->userdata;
+    pthread_mutex_lock(&(localticc2531->usb_mutex));
+    libusb_devices_cnt = libusb_get_device_list(localticc2531->libusb_ctx, &libusb_devs);
+    pthread_mutex_unlock(&(localticc2531->usb_mutex));
+
+    if (libusb_devices_cnt < 0) {
+        return 0;
+    }
+
+    pthread_mutex_lock(&(localticc2531->usb_mutex));
+    for (ssize_t i = 0; i < libusb_devices_cnt; i++) {
+        struct libusb_device_descriptor dev;
+
+        r = libusb_get_device_descriptor(libusb_devs[i], &dev);
+
+        if (r < 0) {
+            continue;
+        }
+
+        if (dev.idVendor == TICC2531_USB_VENDOR && dev.idProduct == TICC2531_USB_PRODUCT) {
+            snprintf(devname, 32, "ticc2531-%u-%u", libusb_get_bus_number(libusb_devs[i]),
+                     libusb_get_device_address(libusb_devs[i]));
+
+            ticc2531_list_t *d = (ticc2531_list_t *) malloc(sizeof(ticc2531_list_t));
+            num_devs++;
+            d->device = strdup(devname);
+            d->next = devs;
+            devs = d;
+        }
+    }
+
+    libusb_free_device_list(libusb_devs, 1);
+    pthread_mutex_unlock(&(localticc2531->usb_mutex));
+
+    if (num_devs == 0) {
+        *interfaces = NULL;
+        return 0;
+    }
+
+    *interfaces =
+        (cf_params_list_interface_t **) malloc(sizeof(cf_params_list_interface_t *) * num_devs);
+
+    i = 0;
+
+    while (devs != NULL) {
+        ticc2531_list_t *td = devs->next;
+        (*interfaces)[i] =
+            (cf_params_list_interface_t *) malloc(sizeof(cf_params_list_interface_t));
+        memset((*interfaces)[i], 0, sizeof(cf_params_list_interface_t));
+
+        (*interfaces)[i]->interface = devs->device;
+        (*interfaces)[i]->flags = NULL;
+        (*interfaces)[i]->hardware = strdup("ticc2531");
+
+        free(devs);
+        devs = td;
+
+        i++;
+    }
+
+    return num_devs;
+}
+
+void *chantranslate_callback(kis_capture_handler_t *caph, char *chanstr) {
+    local_channel_t *ret_localchan;
+    unsigned int parsechan;
+    char errstr[STATUS_MAX];
+
+    if (sscanf(chanstr, "%u", &parsechan) != 1) {
+        snprintf(errstr, STATUS_MAX, "1 unable to parse requested channel '%s'; ticc2531 channels "
+                "are from 11 to 26", chanstr);
+        cf_send_message(caph, errstr, MSGFLAG_INFO);
+        return NULL;
+    }
+
+    if (parsechan > 26 || parsechan < 11) {
+        snprintf(errstr, STATUS_MAX, "2 unable to parse requested channel '%u'; ticc2531 channels "
+                "are from 11 to 26", parsechan);
+        cf_send_message(caph, errstr, MSGFLAG_INFO);
+        return NULL;
+    }
+
+    ret_localchan = (local_channel_t *) malloc(sizeof(local_channel_t));
+    ret_localchan->channel = parsechan;
+    return ret_localchan;
+}
+
+int open_callback(kis_capture_handler_t *caph, uint32_t seqno, char *definition,
+        char *msg, uint32_t *dlt, char **uuid, KismetExternal__Command *frame,
+        cf_params_interface_t **ret_interface,
+        cf_params_spectrum_t **ret_spectrum) {
+
+    char *placeholder = NULL;
+    int placeholder_len;
+    char *interface;
+    char errstr[STATUS_MAX];
+
+    *ret_spectrum = NULL;
+    *ret_interface = cf_params_interface_new();
+
+    int x;
+    int busno = -1, devno = -1;
+
+    libusb_device **libusb_devs = NULL;
+    libusb_device *matched_dev = NULL;
+    ssize_t libusb_devices_cnt = 0;
+    int r;
+
+    int matched_device = 0;
+    char cap_if[32];
+    
+    ssize_t i;
+
+    char *localchanstr = NULL;
+    unsigned int *localchan = NULL;
+
+    local_ticc2531_t *localticc2531 = (local_ticc2531_t *) caph->userdata;
+
+    if ((placeholder_len = cf_parse_interface(&placeholder, definition)) <= 0) {
+        snprintf(msg, STATUS_MAX, "Unable to find interface in definition"); 
+        return 0;
+    }
+
+    interface = strndup(placeholder, placeholder_len);
+
+    /* Look for the interface type */
+    if (strstr(interface, "ticc2531") != interface) {
+        snprintf(msg, STATUS_MAX, "Unable to find ti cc2531 interface"); 
+        free(interface);
+        return -1;
+    }
+
+    /* Look for interface-bus-dev */
+    x = sscanf(interface, "ticc2531-%d-%d", &busno, &devno);
+
+    free(interface);
+
+    /* If we don't have a valid busno/devno or malformed interface name */
+    if (x != -1 && x != 2) {
+        snprintf(msg, STATUS_MAX, "Malformed ticc2531 interface, expected 'ticc2531' or "
+                "'ticc2531-bus#-dev#'"); 
+        return -1;
+    }
+
+    pthread_mutex_lock(&(localticc2531->usb_mutex));
+    libusb_devices_cnt = libusb_get_device_list(localticc2531->libusb_ctx, &libusb_devs);
+    pthread_mutex_unlock(&(localticc2531->usb_mutex));
+
+    if (libusb_devices_cnt < 0) {
+        snprintf(msg, STATUS_MAX, "Unable to iterate USB devices"); 
+        return -1;
+    }
+    
+    pthread_mutex_lock(&(localticc2531->usb_mutex));
+    for (i = 0; i < libusb_devices_cnt; i++) {
+        struct libusb_device_descriptor dev;
+
+        r = libusb_get_device_descriptor(libusb_devs[i], &dev);
+
+        if (r < 0) {
+            continue;
+        }
+
+        if (dev.idVendor == TICC2531_USB_VENDOR && dev.idProduct == TICC2531_USB_PRODUCT) {
+            if (busno >= 0) {
+                if (busno == libusb_get_bus_number(libusb_devs[i]) &&
+                        devno == libusb_get_device_address(libusb_devs[i])) {
+                    matched_device = 1;
+                    matched_dev = libusb_devs[i];
+                    break;
+                }
+            } else {
+                matched_device = 1;
+                busno = libusb_get_bus_number(libusb_devs[i]);
+                devno = libusb_get_device_address(libusb_devs[i]);
+                matched_dev = libusb_devs[i];
+                break;
+            }
+        }
+    }
+
+    if (!matched_device) {
+        snprintf(msg, STATUS_MAX, "Unable to find ticc2531 USB device");
+        return -1;
+    }
+
+    libusb_free_device_list(libusb_devs, 1);
+    pthread_mutex_unlock(&(localticc2531->usb_mutex));
+
+    snprintf(cap_if, 32, "ticc2531-%u-%u", busno, devno);
+
+    // try pulling the channel
+    if ((placeholder_len = cf_find_flag(&placeholder, "channel", definition)) > 0) {
+        localchanstr = strndup(placeholder, placeholder_len);
+        localchan = atoi(localchanstr); 
+        free(localchanstr);
+
+        if (localchan == NULL) {
+            snprintf(msg, STATUS_MAX,
+                    "ticc2531 could not parse channel= option provided in source "
+                    "definition");
+            return -1;
+        }
+    } else {
+        localchan = (unsigned int *) malloc(sizeof(unsigned int));
+        *localchan = 11;
+    }
+
+
+    localticc2531->devno = devno;
+    localticc2531->busno = busno;
+
+    /* Make a spoofed, but consistent, UUID based on the adler32 of the interface name 
+     * and the location in the bus */
+    if ((placeholder_len = cf_find_flag(&placeholder, "uuid", definition)) > 0) {
+        *uuid = strndup(placeholder, placeholder_len);
+    } else {
+        snprintf(errstr, STATUS_MAX, "%08X-0000-0000-0000-%06X%06X",
+                adler32_csum((unsigned char *) "kismet_cap_ti_cc2531", 
+                    strlen("kismet_cap_ti_cc2531")) & 0xFFFFFFFF,
+                busno, devno);
+        *uuid = strdup(errstr);
+    }
+
+    (*ret_interface)->capif = strdup(cap_if);
+    (*ret_interface)->hardware = strdup("ticc2531");
+
+    /* TI CC 2531 supports 11-26 */
+    (*ret_interface)->channels = (char **) malloc(sizeof(char *) * 16);
+    for (int i = 11; i < 27; i++) {
+        char chstr[4];
+        snprintf(chstr, 4, "%d", i);
+        (*ret_interface)->channels[i - 11] = strdup(chstr);
+    }
+
+    (*ret_interface)->channels_len = 16;
+
+    pthread_mutex_lock(&(localticc2531->usb_mutex));
+
+    /* Try to open it */
+    r = libusb_open(matched_dev, &localticc2531->ticc2531_handle);
+
+    if (r < 0) {
+        snprintf(errstr, STATUS_MAX, "Unable to open ticc2531 USB interface: %s", 
+                libusb_strerror((enum libusb_error) r));
+        pthread_mutex_unlock(&(localticc2531->usb_mutex));
+        return -1;
+    }
+
+    if (libusb_kernel_driver_active(localticc2531->ticc2531_handle, 0)) {
+        r = libusb_detach_kernel_driver(localticc2531->ticc2531_handle, 0); 
+
+        if (r < 0) {
+            snprintf(errstr, STATUS_MAX, "Unable to open ticc2531 USB interface, "
+                    "could not disconnect kernel drivers: %s",
+                    libusb_strerror((enum libusb_error) r));
+            pthread_mutex_unlock(&(localticc2531->usb_mutex));
+            return -1;
+        }
+    }
+
+    r = libusb_set_configuration(localticc2531->ticc2531_handle, 1);
+    if (r < 0) {
+        snprintf(errstr, STATUS_MAX,
+                 "Unable to open ticc2531 USB interface; could not set USB configuration.  Has "
+                 "your device been flashed with the sniffer firmware?");
+        pthread_mutex_unlock(&(localticc2531->usb_mutex));
+        return -1;
+    }
+
+    /* Try to claim it */
+    r = libusb_claim_interface(localticc2531->ticc2531_handle, 0);
+    if (r < 0) {
+        if (r == LIBUSB_ERROR_BUSY) {
+            /* Try to detach the kernel driver */
+            r = libusb_detach_kernel_driver(localticc2531->ticc2531_handle, 0);
+            if (r < 0) {
+                snprintf(errstr, STATUS_MAX, "Unable to open ticc2531 USB interface, and unable "
+                        "to disconnect existing driver: %s", 
+                        libusb_strerror((enum libusb_error) r));
+                pthread_mutex_unlock(&(localticc2531->usb_mutex));
+                return -1;
+            }
+        } else {
+            snprintf(errstr, STATUS_MAX, "Unable to open ticc2531 USB interface: %s",
+                    libusb_strerror((enum libusb_error) r));
+            pthread_mutex_unlock(&(localticc2531->usb_mutex));
+            return -1;
+        }
+    }
+   
+    pthread_mutex_unlock(&(localticc2531->usb_mutex));
+
+    ticc2531_set_power(caph, 0x04, TICC2531_POWER_RETRIES);
+
+    ticc2531_set_channel(caph, *localchan);
+    
+    localticc2531->channel = *localchan;
+
+    ticc2531_enter_promisc_mode(caph);
+
+    localticc2531->ready = true;
+
+    return 1;
+}
+
+int chancontrol_callback(kis_capture_handler_t *caph, uint32_t seqno, void *privchan, char *msg) {
+    local_ticc2531_t *localticc2531 = (local_ticc2531_t *) caph->userdata;
+    local_channel_t *channel = (local_channel_t *) privchan;
+    int r;
+
+    if (privchan == NULL) {
+        return 0;
+    }
+    
+    localticc2531->ready = false;
+
+    ticc2531_exit_promisc_mode(caph);
+
+    r = ticc2531_set_channel(caph, channel->channel);
+
+    if (r < 0)
+        return -1;
+
+    localticc2531->channel = channel->channel;
+
+    ticc2531_enter_promisc_mode(caph);
+
+    localticc2531->ready = true;
+   
+    return 1;
+}
+
+/* Run a standard glib mainloop inside the capture thread */
+void capture_thread(kis_capture_handler_t *caph) {
+    local_ticc2531_t *localticc2531 = (local_ticc2531_t *) caph->userdata;
+    char errstr[STATUS_MAX];
+
+    uint8_t usb_buf[256];
+
+    int buf_rx_len, r;
+
+    while (1) {
+        if (caph->spindown) {
+            /* close usb */
+            if (localticc2531->ticc2531_handle) {
+                libusb_close(localticc2531->ticc2531_handle);
+                localticc2531->ticc2531_handle = NULL;
+            }
+
+            break;
+        }
+
+        if (localticc2531->ready) {
+            buf_rx_len = ticc2531_receive_payload(caph, usb_buf, 256);
+            if (buf_rx_len < 0) {
+                snprintf(errstr, STATUS_MAX, "TI CC 2531 interface 'ticc2531-%u-%u' closed "
+                        "unexpectedly", localticc2531->busno, localticc2531->devno);
+                cf_send_error(caph, 0, errstr);
+                cf_handler_spindown(caph);
+                break;
+            }
+
+            /* Skip runt packets caused by timeouts */
+            if (buf_rx_len == 1)
+                continue;
+
+            /* the devices look to report a 4 byte counter/heartbeat, skip it */
+            if (buf_rx_len <= 7)
+                continue;
+
+            while (1) {
+                struct timeval tv;
+
+                gettimeofday(&tv, NULL);
+
+                if ((r = cf_send_data(caph,
+                                NULL, NULL, NULL,
+                                tv,
+                                0,
+                                buf_rx_len, usb_buf)) < 0) {
+                    cf_send_error(caph, 0, "unable to send DATA frame");
+                    cf_handler_spindown(caph);
+                } else if (r == 0) {
+                    cf_handler_wait_ringbuffer(caph);
+                    continue;
+                } else {
+                    break;
+                }
+            }
+        }
+    }
+
+    cf_handler_spindown(caph);
+}
+
+
+int main(int argc, char *argv[]) {
+    local_ticc2531_t localticc2531 = {
+        .libusb_ctx = NULL,
+        .ticc2531_handle = NULL,
+        .caph = NULL,
+        .error_ctr = 0,
+	.soft_reset = 0,
+    };
+
+    pthread_mutex_init(&(localticc2531.usb_mutex), NULL);
+
+    kis_capture_handler_t *caph = cf_handler_init("ticc2531");
+    int r;
+
+    if (caph == NULL) {
+        fprintf(stderr, "FATAL: Could not allocate basic handler data, your system "
+                "is very low on RAM or something is wrong.\n");
+        return -1;
+    }
+
+    r = libusb_init(&localticc2531.libusb_ctx);
+    if (r < 0) {
+        return -1;
+    }
+
+    localticc2531.caph = caph;
+
+    /* Set the local data ptr */
+    cf_handler_set_userdata(caph, &localticc2531);
+
+    /* Set the callback for opening  */
+    cf_handler_set_open_cb(caph, open_callback);
+
+    /* Set the callback for probing an interface */
+    cf_handler_set_probe_cb(caph, probe_callback);
+
+    /* Set the list callback */
+    cf_handler_set_listdevices_cb(caph, list_callback);
+
+    /* Channel callbacks */
+    cf_handler_set_chantranslate_cb(caph, chantranslate_callback);
+    cf_handler_set_chancontrol_cb(caph, chancontrol_callback);
+
+    /* Set the capture thread */
+    cf_handler_set_capture_cb(caph, capture_thread);
+
+    if (cf_handler_parse_opts(caph, argc, argv) < 1) {
+        cf_print_help(caph, argv[0]);
+        return -1;
+    }
+
+    /* Support remote capture by launching the remote loop */
+    cf_handler_remote_capture(caph);
+
+    /* Jail our ns */
+    cf_jail_filesystem(caph);
+
+    /* Strip our privs */
+    cf_drop_most_caps(caph);
+
+    cf_handler_loop(caph);
+    libusb_exit(localticc2531.libusb_ctx);
+    
+    return 0;
+}
+

--- a/capture_ti_cc_2531/ti_cc2531.h
+++ b/capture_ti_cc_2531/ti_cc2531.h
@@ -1,0 +1,28 @@
+#include "../config.h"
+
+#ifndef __TICC2531_H__
+#define __TICC2531_H__
+
+#define TICC2531_USB_VENDOR        0x0451 
+#define TICC2531_USB_PRODUCT       0x16ae 
+
+#define TICC2531_GET_IDENT 0xC0
+#define TICC2531_SET_POWER 0xC5
+#define TICC2531_GET_POWER 0xC6
+#define TICC2531_SET_START 0xD0
+#define TICC2531_SET_END   0xD1
+#define TICC2531_SET_CHAN  0xD2 // 0x0d (idx 0) + data)0x00 (idx 1)
+#define TICC2531_DIR_OUT   0x40
+#define TICC2531_DIR_IN    0xC0
+#define TICC2531_TIMEOUT   100 // 2500
+#define TICC2531_DATA_TIMEOUT   200
+
+#define TICC2531_POWER_RETRIES 10
+
+#define TICC2531_DATA_EP 0x83
+
+#define TICC2531 0x01
+
+#endif
+
+

--- a/configure
+++ b/configure
@@ -625,6 +625,7 @@ LIBOBJS
 BUILD_CAPTURE_NXP_KW41Z
 BUILD_CAPTURE_NRF_51822
 BUILD_CAPTURE_UBERTOOTH_ONE
+BUILD_CAPTURE_TI_CC_2531
 BUILD_CAPTURE_TI_CC_2540
 BUILD_CAPTURE_NRF_MOUSEJACK
 BUILD_CAPTURE_FREAKLABS_ZIGBEE
@@ -4136,6 +4137,7 @@ BUILD_CAPTURE_SDR_RTLADSB=1
 BUILD_CAPTURE_FREAKLABS_ZIGBEE=1
 BUILD_CAPTURE_NRF_MOUSEJACK=0
 BUILD_CAPTURE_TI_CC_2540=0
+BUILD_CAPTURE_TI_CC_2531=0
 BUILD_CAPTURE_UBERTOOTH_ONE=0
 BUILD_CAPTURE_NRF_51822=0
 BUILD_CAPTURE_NXP_KW41Z=0
@@ -12304,6 +12306,12 @@ if test "$have_usb" = "yes"; then
     DATASOURCE_BINS="$DATASOURCE_BINS \$(CAPTURE_TI_CC_2540)"
 fi
 
+BUILD_CAPTURE_TI_CC_2531=0
+if test "$have_usb" = "yes"; then
+    BUILD_CAPTURE_TI_CC_2531=1
+    DATASOURCE_BINS="$DATASOURCE_BINS \$(CAPTURE_TI_CC_2531)"
+fi
+
 BUILD_CAPTURE_LINUX_BLUETOOTH=0
 if test "$linux" = "yes"; then
     BUILD_CAPTURE_LINUX_BLUETOOTH=1
@@ -12316,6 +12324,7 @@ DATASOURCE_BINS="$DATASOURCE_BINS \$(CAPTURE_NRF_51822)"
 
 BUILD_CAPTURE_NXP_KW41Z=1
 DATASOURCE_BINS="$DATASOURCE_BINS \$(CAPTURE_NXP_KW41Z)"
+
 
 if test "$darwin" = "yes"; then
 	suidgroup="staff"
@@ -12516,11 +12525,12 @@ sharedatadir=${sharedatadir}
 
 
 
+
 #AC_SUBST(CPPFLAGS)
 #AC_SUBST(CFLAGS)
 #AC_SUBST(CXXFLAGS)
 
-ac_config_files="$ac_config_files Makefile Makefile.inc packaging/kismet.pc packaging/systemd/kismet.service packaging/systemd/debug/kismet-debug.service capture_linux_bluetooth/Makefile capture_linux_wifi/Makefile capture_osx_corewlan_wifi/Makefile capture_sdr_rtl433/Makefile capture_sdr_rtlamr/Makefile capture_sdr_rtladsb/Makefile capture_freaklabs_zigbee/Makefile capture_nrf_mousejack/Makefile capture_ti_cc_2540/Makefile capture_ubertooth_one/Makefile capture_nrf_51822/Makefile capture_nxp_kw41z/Makefile"
+ac_config_files="$ac_config_files Makefile Makefile.inc packaging/kismet.pc packaging/systemd/kismet.service packaging/systemd/debug/kismet-debug.service capture_linux_bluetooth/Makefile capture_linux_wifi/Makefile capture_osx_corewlan_wifi/Makefile capture_sdr_rtl433/Makefile capture_sdr_rtlamr/Makefile capture_sdr_rtladsb/Makefile capture_freaklabs_zigbee/Makefile capture_nrf_mousejack/Makefile capture_ti_cc_2540/Makefile capture_ti_cc_2531/Makefile capture_ubertooth_one/Makefile capture_nrf_51822/Makefile capture_nxp_kw41z/Makefile"
 
 cat >confcache <<\_ACEOF
 # This file is a shell script that caches the results of configure
@@ -13228,6 +13238,7 @@ do
     "capture_freaklabs_zigbee/Makefile") CONFIG_FILES="$CONFIG_FILES capture_freaklabs_zigbee/Makefile" ;;
     "capture_nrf_mousejack/Makefile") CONFIG_FILES="$CONFIG_FILES capture_nrf_mousejack/Makefile" ;;
     "capture_ti_cc_2540/Makefile") CONFIG_FILES="$CONFIG_FILES capture_ti_cc_2540/Makefile" ;;
+    "capture_ti_cc_2531/Makefile") CONFIG_FILES="$CONFIG_FILES capture_ti_cc_2531/Makefile" ;;
     "capture_ubertooth_one/Makefile") CONFIG_FILES="$CONFIG_FILES capture_ubertooth_one/Makefile" ;;
     "capture_nrf_51822/Makefile") CONFIG_FILES="$CONFIG_FILES capture_nrf_51822/Makefile" ;;
     "capture_nxp_kw41z/Makefile") CONFIG_FILES="$CONFIG_FILES capture_nxp_kw41z/Makefile" ;;
@@ -13905,6 +13916,13 @@ if test "$BUILD_CAPTURE_TI_CC_2540" = 1; then
         echo "yes";
 else
         echo "no (libusb-1.0 not available)";
+fi
+
+printf "     TI CC 2531 Zigbee: "
+if test "$BUILD_CAPTURE_TI_CC_2531" = 1; then
+	echo "yes";
+else
+	echo "no (libusb-1.0 not available)";
 fi
 
 printf "         Ubertooth One: "

--- a/configure.ac
+++ b/configure.ac
@@ -37,6 +37,7 @@ BUILD_CAPTURE_SDR_RTLADSB=1
 BUILD_CAPTURE_FREAKLABS_ZIGBEE=1
 BUILD_CAPTURE_NRF_MOUSEJACK=0
 BUILD_CAPTURE_TI_CC_2540=0
+BUILD_CAPTURE_TI_CC_2531=0
 BUILD_CAPTURE_UBERTOOTH_ONE=0
 BUILD_CAPTURE_NRF_51822=0
 BUILD_CAPTURE_NXP_KW41Z=0
@@ -1482,6 +1483,12 @@ if test "$have_usb" = "yes"; then
     DATASOURCE_BINS="$DATASOURCE_BINS \$(CAPTURE_TI_CC_2540)"
 fi
 
+BUILD_CAPTURE_TI_CC_2531=0
+if test "$have_usb" = "yes"; then
+    BUILD_CAPTURE_TI_CC_2531=1
+    DATASOURCE_BINS="$DATASOURCE_BINS \$(CAPTURE_TI_CC_2531)"
+fi
+
 BUILD_CAPTURE_LINUX_BLUETOOTH=0
 if test "$linux" = "yes"; then
     BUILD_CAPTURE_LINUX_BLUETOOTH=1
@@ -1494,6 +1501,7 @@ DATASOURCE_BINS="$DATASOURCE_BINS \$(CAPTURE_NRF_51822)"
 
 BUILD_CAPTURE_NXP_KW41Z=1
 DATASOURCE_BINS="$DATASOURCE_BINS \$(CAPTURE_NXP_KW41Z)"
+
 
 if test "$darwin" = "yes"; then
 	suidgroup="staff"
@@ -1616,6 +1624,7 @@ AC_SUBST(BUILD_CAPTURE_SDR_RTLADSB)
 AC_SUBST(BUILD_CAPTURE_FREAKLABS_ZIGBEE)
 AC_SUBST(BUILD_CAPTURE_NRF_MOUSEJACK)
 AC_SUBST(BUILD_CAPTURE_TI_CC_2540)
+AC_SUBST(BUILD_CAPTURE_TI_CC_2531)
 AC_SUBST(BUILD_CAPTURE_UBERTOOTH_ONE)
 AC_SUBST(BUILD_CAPTURE_NRF_51822)
 AC_SUBST(BUILD_CAPTURE_NXP_KW41Z)
@@ -1624,7 +1633,7 @@ AC_SUBST(BUILD_CAPTURE_NXP_KW41Z)
 #AC_SUBST(CFLAGS)
 #AC_SUBST(CXXFLAGS)
 
-AC_CONFIG_FILES([Makefile Makefile.inc packaging/kismet.pc packaging/systemd/kismet.service packaging/systemd/debug/kismet-debug.service capture_linux_bluetooth/Makefile capture_linux_wifi/Makefile capture_osx_corewlan_wifi/Makefile capture_sdr_rtl433/Makefile capture_sdr_rtlamr/Makefile capture_sdr_rtladsb/Makefile capture_freaklabs_zigbee/Makefile capture_nrf_mousejack/Makefile capture_ti_cc_2540/Makefile capture_ubertooth_one/Makefile capture_nrf_51822/Makefile capture_nxp_kw41z/Makefile])
+AC_CONFIG_FILES([Makefile Makefile.inc packaging/kismet.pc packaging/systemd/kismet.service packaging/systemd/debug/kismet-debug.service capture_linux_bluetooth/Makefile capture_linux_wifi/Makefile capture_osx_corewlan_wifi/Makefile capture_sdr_rtl433/Makefile capture_sdr_rtlamr/Makefile capture_sdr_rtladsb/Makefile capture_freaklabs_zigbee/Makefile capture_nrf_mousejack/Makefile capture_ti_cc_2540/Makefile capture_ti_cc_2531/Makefile capture_ubertooth_one/Makefile capture_nrf_51822/Makefile capture_nxp_kw41z/Makefile])
 AC_OUTPUT
 
 echo
@@ -1714,6 +1723,13 @@ if test "$BUILD_CAPTURE_TI_CC_2540" = 1; then
         echo "yes";
 else
         echo "no (libusb-1.0 not available)";
+fi
+
+printf "     TI CC 2531 Zigbee: "
+if test "$BUILD_CAPTURE_TI_CC_2531" = 1; then
+	echo "yes";
+else
+	echo "no (libusb-1.0 not available)";
 fi
 
 printf "         Ubertooth One: "

--- a/datasource_ti_cc_2531.cc
+++ b/datasource_ti_cc_2531.cc
@@ -1,0 +1,137 @@
+/*
+    This file is part of Kismet
+
+    Kismet is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    Kismet is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Kismet; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+#include "datasource_ti_cc_2531.h"
+
+//#define TLVHEADER
+
+void kis_datasource_ticc2531::handle_rx_packet(kis_packet *packet) {
+#ifdef TLVHEADER
+    typedef struct {
+        uint16_t type; //type identifier
+        uint16_t length; // number of octets for type in value field (not including padding
+        uint32_t value; // data for type
+    } tap_tlv;
+    
+    typedef struct {
+        uint8_t version; // currently zero
+        uint8_t reserved; // must be zero
+        uint16_t length; // total length of header and tlvs in octets, min 4 and must be multiple of 4
+        tap_tlv tlv[2];//tap tlvs 3 if we get channel later
+        uint8_t payload[0];	        
+        ////payload + fcs per fcs type
+    } zigbee_tap;
+#endif
+    auto cc_chunk = 
+        packet->fetch<kis_datachunk>(pack_comp_linkframe);
+
+/*
+    printf("datasource 2531 got a packet\n");
+    for(unsigned int i=0;i<cc_chunk->length;i++)
+    {
+        printf("%02X",cc_chunk->data[i]);
+    }
+    printf("\n");
+*/
+
+    // If we can't validate the basics of the packet at the phy capture level, throw it out.
+    // We don't get rid of invalid btle contents, but we do get rid of invalid USB frames that
+    // we can't decipher - we can't even log them sanely!
+    
+    if (cc_chunk->length < 8) {
+        // fmt::print(stderr, "debug - cc2531 too short ({} < 8)\n", cc_chunk->length);
+        delete(packet);
+        return;
+    }
+
+    unsigned int cc_len = cc_chunk->data[1];
+    if (cc_len != cc_chunk->length - 3) {
+        // fmt::print(stderr, "debug - cc2531 invalid packet length ({} != {})\n", cc_len, cc_chunk->length - 3);
+        delete(packet);
+        return;
+    }
+
+    unsigned int cc_payload_len = cc_chunk->data[7] - 0x02;
+    if (cc_payload_len + 8 != cc_chunk->length - 2) {
+        // fmt::print(stderr, "debug - cc2531 invalid payload length ({} != {})\n", cc_payload_len + 8, cc_chunk->length - 2);
+        delete(packet);
+        return;
+    }
+
+    uint8_t fcs1 = cc_chunk->data[cc_chunk->length - 2];
+    uint8_t fcs2 = cc_chunk->data[cc_chunk->length - 1];
+
+    unsigned char crc_ok = fcs2 & (1 << 7);
+
+    // unsigned char corr = fcs2 & 0x7f;
+
+    if(crc_ok > 0)
+    {
+        #ifdef TLVHEADER
+	int rssi = (fcs1 + (int)pow(2,7)) % (int)pow(2,8) - (int)pow(2,7) - 73;
+        // We can make a valid payload from this much
+        auto conv_buf_len = sizeof(zigbee_tap) + cc_payload_len;// + (sizeof(tap_tlv))-2;// - 2;
+        zigbee_tap *conv_header = reinterpret_cast<zigbee_tap *>(new uint8_t[conv_buf_len]);
+        memset(conv_header, 0, conv_buf_len);
+
+        // Copy the actual packet payload into the header
+        memcpy(conv_header->payload, &cc_chunk->data[8], cc_payload_len);
+
+        conv_header->version = 0;//currently only one version
+        conv_header->reserved = 0;//must be set to 0
+
+        //fcs setting
+        conv_header->tlv[0].type = 0;
+        conv_header->tlv[0].length = 1;
+        conv_header->tlv[0].value = 0;
+
+        //rssi
+        conv_header->tlv[1].type = 10;
+        conv_header->tlv[1].length = 1;
+        conv_header->tlv[1].value = rssi * -1;
+        /*
+        //channel
+        conv_header->tlv[2].type = 3;
+        conv_header->tlv[2].length = 3;
+        conv_header->tlv[2].value = 11;//need to try to pull from some where, but it is not in the packet
+        */
+        //size
+        conv_header->length = sizeof(conv_header)+sizeof(conv_header->tlv)-4;
+        cc_chunk->set_data((uint8_t *)conv_header, conv_buf_len, false);
+        cc_chunk->dlt = KDLT_IEEE802_15_4_TAP; 	
+        #else
+	
+        //so this works
+        uint8_t payload[256]; memset(payload,0x00,256);
+        memcpy(payload,&cc_chunk->data[8],cc_payload_len);	
+        // Replace the existing packet data with this and update the DLT
+        cc_chunk->set_data(payload, cc_payload_len, false);
+        cc_chunk->dlt = KDLT_IEEE802_15_4_NOFCS; 
+	
+        #endif
+	// Pass the packet on
+        packetchain->process_packet(packet);
+
+    }
+    else
+    {
+    	delete(packet);
+	    return;
+    }
+}
+

--- a/datasource_ti_cc_2531.h
+++ b/datasource_ti_cc_2531.h
@@ -1,0 +1,117 @@
+/*
+    This file is part of Kismet
+
+    Kismet is free software; you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation; either version 2 of the License, or
+    (at your option) any later version.
+
+    Kismet is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with Kismet; if not, write to the Free Software
+    Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+*/
+
+#ifndef __DATASOURCE_TI_CC2531_H__
+#define __DATASOURCE_TI_CC2531_H__
+
+#include "config.h"
+
+#define HAVE_TI_CC2531_DATASOURCE
+
+#include "kis_datasource.h"
+#include "dlttracker.h"
+
+class kis_datasource_ticc2531;
+typedef std::shared_ptr<kis_datasource_ticc2531> shared_datasource_ticc2531;
+
+#ifndef KDLT_IEEE802_15_4_TAP
+#define KDLT_IEEE802_15_4_TAP             283 
+#endif
+
+#ifndef KDLT_IEEE802_15_4_NOFCS
+#define KDLT_IEEE802_15_4_NOFCS           230
+#endif
+
+class kis_datasource_ticc2531 : public kis_datasource {
+public:
+    kis_datasource_ticc2531(shared_datasource_builder in_builder,
+            std::shared_ptr<kis_recursive_timed_mutex> mutex) :
+        kis_datasource(in_builder, mutex) {
+
+        // Set the capture binary
+        set_int_source_ipc_binary("kismet_cap_ti_cc_2531");
+
+	//set_int_source_dlt(KDLT_IEEE802_15_4_NOFCS);
+        set_int_source_dlt(KDLT_IEEE802_15_4_TAP);
+
+        pack_comp_decap =
+            packetchain->register_packet_component("DECAP");
+        pack_comp_radiodata = 
+            packetchain->register_packet_component("RADIODATA");
+    }
+
+    virtual ~kis_datasource_ticc2531() { };
+
+protected:
+    virtual void handle_rx_packet(kis_packet *packet) override;
+
+    int pack_comp_decap, pack_comp_radiodata;
+};
+
+
+class datasource_ticc2531_builder : public kis_datasource_builder {
+public:
+    datasource_ticc2531_builder(int in_id) :
+        kis_datasource_builder(in_id) {
+
+        register_fields();
+        reserve_fields(NULL);
+        initialize();
+    }
+
+    datasource_ticc2531_builder(int in_id, std::shared_ptr<tracker_element_map> e) :
+        kis_datasource_builder(in_id, e) {
+
+        register_fields();
+        reserve_fields(e);
+        initialize();
+    }
+
+    datasource_ticc2531_builder() :
+        kis_datasource_builder() {
+
+        register_fields();
+        reserve_fields(NULL);
+        initialize();
+    }
+
+    virtual ~datasource_ticc2531_builder() { }
+
+    virtual shared_datasource build_datasource(shared_datasource_builder in_sh_this,
+            std::shared_ptr<kis_recursive_timed_mutex> mutex) override {
+        return shared_datasource_ticc2531(new kis_datasource_ticc2531(in_sh_this, mutex));
+    }
+
+    virtual void initialize() override {
+        // Set up our basic parameters for the linux wifi driver
+        
+        set_source_type("ticc2531");
+        set_source_description("TI CC2531 with sniffer firmware");
+
+        set_probe_capable(true);
+        set_list_capable(true);
+        set_local_capable(true);
+        set_remote_capable(true);
+        set_passive_capable(false);
+        set_tune_capable(true);
+	set_hop_capable(true);
+    }
+};
+
+#endif
+

--- a/kismet_server.cc
+++ b/kismet_server.cc
@@ -76,6 +76,7 @@
 #include "datasource_nrf_51822.h"
 #include "datasource_ubertooth_one.h"
 #include "datasource_nxp_kw41z.h"
+#include "datasource_ti_cc_2531.h"
 
 #include "logtracker.h"
 #include "kis_ppilogfile.h"
@@ -891,6 +892,7 @@ int main(int argc, char *argv[], char *envp[]) {
     datasourcetracker->register_datasource(shared_datasource_builder(new datasource_nrf51822_builder()));
     datasourcetracker->register_datasource(shared_datasource_builder(new datasource_ubertooth_one_builder()));
     datasourcetracker->register_datasource(shared_datasource_builder(new datasource_nxpkw41z_builder()));
+    datasourcetracker->register_datasource(shared_datasource_builder(new datasource_ticc2531_builder()));
 
     // Create the database logger as a global because it's a special case
     kis_database_logfile::create_kisdatabaselog();


### PR DESCRIPTION
Basic support for the TI CC2531 which will save to a pcap. There is a define in the datasource that will allow you to select which dlt and packet format you would like to use.
The capture source isn't as aggressive with resetting. My thought being that there isn't usually a high volume of traffic with zigbee (compared to btle) so this gives it more chances of finding something before resetting.