### PR TITLE
add some helpful udev rules

### DIFF
--- a/packaging/udev/99-freaklabs.rules
+++ b/packaging/udev/99-freaklabs.rules
@@ -1,0 +1,3 @@
+#this rule symlinks freakusb devices to /dev/freakusb# with # starting at 1
+#WARNING the rule file included in gpsd sets this as /dev/gps0
+ACTION=="bind" SUBSYSTEM=="usb", DRIVERS=="usb", ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60", PROGRAM="/bin/sh -c 'echo $(($(ls /dev/freakusb* 2>/dev/null| tail -n1 | sed -e s#/dev/freakusb## )+1))'", SYMLINK+="freakusb%c"

--- a/packaging/udev/99-kismet-gps.rules
+++ b/packaging/udev/99-kismet-gps.rules
@@ -1,0 +1,7 @@
+#This rule symlinks known gps devices to /dev/gps-kismet# with # starting at 1
+#This rule is intended to be similar to the rules file included with gpsd, with items that conflict removed
+#Example: the gpsd.rules file grabs the kismet support freakusb device :-( ATTRS{idVendor}=="10c4", ATTRS{idProduct}=="ea60"
+#Only the most common gps types are included right now to avoid potential conflicts
+
+ACTION=="add" SUBSYSTEM=="usb", DRIVERS=="cdc_acm", ATTRS{idVendor}=="1546", ATTRS{idProduct}=="01a7", ATTRS{manufacturer}=="u-blox AG - www.u-blox.com", ATTRS{product}=="u-blox 7 - GPS/GNSS Receiver", PROGRAM="/bin/sh -c 'echo $(($(ls /dev/gps-kismet* 2>/dev/null| tail -n1 | sed -e s#/dev/gps-kismet## )+1))'", SYMLINK+="gps-kismet%c"
+ACTION=="add" SUBSYSTEM=="tty", ATTRS{idVendor}=="067b", ATTRS{idProduct}=="2303", PROGRAM="/bin/sh -c 'echo $(($(ls /dev/gps-kismet* 2>/dev/null| tail -n1 | sed -e s#/dev/gps-kismet## )+1))'", SYMLINK+="gps-kismet%c"

--- a/packaging/udev/99-nxp_kw41z.rules
+++ b/packaging/udev/99-nxp_kw41z.rules
@@ -1,0 +1,2 @@
+#this rule symlinks NXP KW41Z devices to /dev/nxp_kw41z# with # starting at 1
+ACTION=="bind" SUBSYSTEM=="usb", DRIVERS=="usb", ATTRS{idVendor}=="15a2", ATTRS{idProduct}=="0300", PROGRAM="/bin/sh -c 'echo $(($(ls /dev/nxp_kw41z* 2>/dev/null| tail -n1 | sed -e s#/dev/nxp_kw41z## )+1))'", SYMLINK+="nxp_kw41z%c"

--- a/packaging/udev/README
+++ b/packaging/udev/README
@@ -1,0 +1,9 @@
+Kismet Helper UDEV rules
+
+# Purpose
+
+   Many devices show up as /dev/ttyUSB* and /dev/ttyACM*, this helps sort them out
+
+# Installing
+
+   Copy the *.rules files into /etc/udev/rules.d, or /lib/udev/rules.d if installed as a package


### PR DESCRIPTION
Add some helpful udev rules to create symlinks for nxp_kw41z and
freaklabs freakusb devices.  Additionally add a udev rule for gps
devices that doesn't conflict with devices kismet uses which are not gps
devices (freakusb and their default vid/pid)