### PR TITLE
Put back DEAUTHFLOOD alert

### DIFF
--- a/phy_80211.h
+++ b/phy_80211.h
@@ -477,7 +477,7 @@ protected:
         alert_longssid_ref, alert_disconinvalid_ref, alert_deauthinvalid_ref,
         alert_dhcpclient_ref, alert_wmm_ref, alert_nonce_zero_ref, 
         alert_nonce_duplicate_ref, alert_11kneighborchan_ref, alert_probechan_ref,
-		alert_rtlwifi_p2p_ref;
+        alert_rtlwifi_p2p_ref, alert_deauthflood_ref;
 
     // Are we allowed to send wepkeys to the client (server config)
     int client_wepkey_allowed;

--- a/phy_80211_components.h
+++ b/phy_80211_components.h
@@ -968,6 +968,8 @@ public:
     __Proxy(client_disconnects, uint64_t, uint64_t, uint64_t, client_disconnects);
     __ProxyIncDec(client_disconnects, uint64_t, uint64_t, client_disconnects);
 
+    __Proxy(client_disconnects_last, uint64_t, uint64_t, uint64_t, client_disconnects_last);
+
     __Proxy(last_sequence, uint64_t, uint64_t, uint64_t, last_sequence);
     __Proxy(bss_timestamp, uint64_t, uint64_t, uint64_t, bss_timestamp);
     time_t last_bss_invalid;
@@ -1098,8 +1100,11 @@ protected:
                 "number of associated clients", &num_associated_clients);
 
         register_field("dot11.device.client_disconnects", 
-                "client disconnects in last second", 
+                "client disconnects message count", 
                 &client_disconnects);
+        register_field("dot11.device.client_disconnects_last",
+                "client disconnects last message",
+                &client_disconnects_last);
 
         register_field("dot11.device.last_sequence", "last sequence number", &last_sequence);
         register_field("dot11.device.bss_timestamp", "last BSS timestamp", &bss_timestamp);
@@ -1251,6 +1256,7 @@ protected:
     int associated_client_map_entry_id;
     std::shared_ptr<tracker_element_uint64> num_associated_clients;
     std::shared_ptr<tracker_element_uint64> client_disconnects;
+    std::shared_ptr<tracker_element_uint64> client_disconnects_last;
 
     std::shared_ptr<tracker_element_uint64> last_sequence;
     std::shared_ptr<tracker_element_uint64> bss_timestamp;


### PR DESCRIPTION
DEAUTH alert will be sent if more than 10 deauthentications or
disassociations are received in one second as done in the
rudimentary mechanism that was added back in 2002:
https://github.com/kismetwireless/kismet/commit/2a132d45ef602d8bde5fbe1d5df8c1c2d673606a

It should be noted that this detection mechanism works better if the
user sets packet_dedup_size to 0 otherwise most of the flooding packets
will be detected as duplicate and so will be discarded.
I would advise to document this limitation.

Fix #227

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>