### PR TITLE
phy_80211_dissectors.cc: fix parsing of IE tags for Assocation Request

### DIFF
--- a/phy_80211_dissectors.cc
+++ b/phy_80211_dissectors.cc
@@ -797,12 +797,15 @@ int kis_80211_phy::packet_dot11_dissector(kis_packet *in_pack) {
                 return 0;
             }
 
-            packinfo->header_offset = 36;
+            packinfo->header_offset = 24;
             fixparm = (fixed_parameters *) &(chunk->data[24]);
 
-            if (fc->subtype == packet_sub_reassociation_req) {
-                packinfo->header_offset += 8;
-            }
+            if (fc->subtype == packet_sub_association_req)
+                packinfo->header_offset += 4;
+            else if (fc->subtype == packet_sub_reassociation_req)
+                packinfo->header_offset += 10;
+            else
+                packinfo->header_offset += 12;
 
             if (fixparm->wep) {
                 packinfo->cryptset |= crypt_wep;


### PR DESCRIPTION
IE tags of Association Request is currently wrongly parsed. When parsing
those requests, kismet sets the packet has corrupted and print this
error: "debug - IE tag structure corrupt"

This error is due to to the header_offset being wrong, it should be set
to 28 instead of 36 as Association Request has a "Fixed Parameters"
field of 4 bytes (2 bytes for Capability Info and 2 bytes for Listen
Interval).

There is the same issue with the Reassociation Request which has a
header_offset of 34 instead of 44 as Reassociation Request has the same
parameters than Association Request plus an additional 6 bytes header
for the Current Address.

Finally, keep the current value of 36 as the default. It will be used
for Probe Response which has a Timestamp of 8 bytes, a Beacon Interval
of 2 bytes and a Capability Info of 2 bytes.

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>