### PR TITLE
 Add NOCLIENTMFP alert

### DIFF
--- a/conf/kismet_alerts.conf
+++ b/conf/kismet_alerts.conf
@@ -101,6 +101,7 @@ alert=MSFDLINKRATE,5/min,1/sec
 alert=MSFNETGEARBEACON,5/min,1/sec
 alert=MALFORMMGMT,5/min,1/sec
 alert=NETSTUMBLER,5/min,1/sec
+alert=NOCLIENTMFP,10/min,1/sec
 alert=NONCEDEGRADE,0/min,0/sec
 alert=NONCEREUSE,0/min,0/sec
 alert=NULLPROBERESP,5/min,1/sec

--- a/phy_80211.h
+++ b/phy_80211.h
@@ -478,7 +478,7 @@ protected:
         alert_longssid_ref, alert_disconinvalid_ref, alert_deauthinvalid_ref,
         alert_dhcpclient_ref, alert_wmm_ref, alert_nonce_zero_ref, 
         alert_nonce_duplicate_ref, alert_11kneighborchan_ref, alert_probechan_ref,
-        alert_rtlwifi_p2p_ref, alert_deauthflood_ref;
+        alert_rtlwifi_p2p_ref, alert_deauthflood_ref, alert_noclientmfp_ref;
 
     // Are we allowed to send wepkeys to the client (server config)
     int client_wepkey_allowed;


### PR DESCRIPTION
This alert will be raised when a Client doesn't support management frame
protection (MFP).

It should be documented that this alert works better when kismet is
locked on a specific channel as it's raised when the Association Request
of the client:
- does not contain RSN IE tag
- or when the MFP capable field of the RSN IE tag is false

Finally, it should be noted that this alert is raised only for clients.
MFP support on AP is already displayed by kismet in the Web UI and
sending an alert for each Beacon or Probe Response sent by the Access
Point will raise too many alerts.

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>