### PR TITLE
alertracker: fix GPS location

### DIFF
--- a/alertracker.cc
+++ b/alertracker.cc
@@ -72,6 +72,10 @@ alert_tracker::alert_tracker() :
     pack_comp_alert =
 		packetchain->register_packet_component("alert");
 
+	// Register the GPS component
+    pack_comp_gps =
+		packetchain->register_packet_component("GPS");
+
 	// Register a KISMET alert type with no rate restrictions
     alert_ref_kismet =
 		register_alert("KISMET", "Server events", sat_day, 0, sat_day, 0, KIS_PHY_ANY);
@@ -318,6 +322,11 @@ int alert_tracker::raise_alert(int in_ref, kis_packet *in_pack,
 
 		// Attach it to the packet
 		acomp->alert_vec.push_back(info);
+		
+		// Also get GPS
+		kis_gps_packinfo *pack_gpsinfo =
+			(kis_gps_packinfo *) in_pack->fetch(pack_comp_gps);
+		info->gps = new kis_gps_packinfo(pack_gpsinfo);
 	}
 
 #ifdef PRELUDE

--- a/alertracker.h
+++ b/alertracker.h
@@ -404,7 +404,7 @@ protected:
 	// Parse a foo/bar rate/unit option
 	int parse_rate_unit(std::string in_ru, alert_time_unit *ret_unit, int *ret_rate);
 
-    int pack_comp_alert;
+    int pack_comp_alert, pack_comp_gps;
     int alert_ref_kismet;
 
     int next_alert_id;


### PR DESCRIPTION
Currently, location values returned in alerts are always set to 0
because gps->info is never set in alertracker.cc. This feature has been
added a few years ago with 46e19e6. However, it did not survive the API
changes especially 33afdf3.

Fix this by retrieving kis_gps_packinfo from in_pack.

Fix #233

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>