### PR TITLE
Fix Web GPS

### DIFF
--- a/conf/kismet.conf
+++ b/conf/kismet.conf
@@ -158,6 +158,7 @@ override_remote_timestamp=true
 # gps=tcp:host=1.2.3.4,port=4352
 # gps=gpsd:host=localhost,port=2947
 # gps=virtual:lat=123.45,lon=45.678,alt=1234
+# gps=web:name=gpsweb
 
 
 

--- a/gpsweb.h
+++ b/gpsweb.h
@@ -49,10 +49,7 @@ public:
             const char *url, const char *method, const char *upload_data,
             size_t *upload_data_size, std::stringstream &stream);
 
-    virtual int httpd_post_iterator(void *coninfo_cls, enum MHD_ValueKind kind, 
-            const char *key, const char *filename, const char *content_type,
-            const char *transfer_encoding, const char *data, 
-            uint64_t off, size_t size);
+    virtual int httpd_post_complete(kis_net_httpd_connection *concls);
 
 protected:
     // Last time we calculated the heading, don't do it more than once every 


### PR DESCRIPTION
Web GPS is broken since commit 616930b6a1c9f91ff851dbc1c9f076b80224d491 which removed msgack. Add it back as it is still documented as a valid API in https://www.kismetwireless.net/docs/readme/gps

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>