### PR TITLE
devicetracker_view.cc: allow a last-time of 0

### DIFF
--- a/devicetracker_view.cc
+++ b/devicetracker_view.cc
@@ -350,10 +350,6 @@ std::shared_ptr<tracker_element> device_tracker_view::device_time_endpoint(const
     auto tv = string_to_n<int64_t>(path[4], 0);
     time_t ts;
 
-    // Don't allow 'all' devices b/c it's really expensive
-    if (tv == 0)
-        return ret;
-
     if (tv < 0)
         ts = time(0) - tv;
     else
@@ -415,10 +411,6 @@ std::shared_ptr<tracker_element> device_tracker_view::device_time_uri_endpoint(c
 
     auto tv = string_to_n<int64_t>(path[3 + extras_sz], 0);
     time_t ts;
-
-    // Don't allow 'all' devices b/c it's really expensive
-    if (tv == 0)
-        return ret;
 
     if (tv < 0)
         ts = time(0) + tv;


### PR DESCRIPTION
Commit b24b61b1b0bbd5ea76a198cf77ff3071ed102440 added a restriction on
last-time that can't be equal to 0.

Remove this limitation as this is allowed for
/devices/last-time/[TIMESTAMP]/devices.json API and can be useful for
users that wan't to retrive all devices of a given type (for example
WiFi APs)

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>