### PR TITLE
kis_datasource.cc: fix error display

### DIFF
--- a/kis_datasource.cc
+++ b/kis_datasource.cc
@@ -415,8 +415,6 @@ void kis_datasource::close_source() {
     ipc_remote.reset();
     ringbuf_handler.reset();
 
-    quiet_errors = true;
-
     if (get_source_error())
         return;
 
@@ -457,9 +455,6 @@ void kis_datasource::trigger_error(std::string in_error) {
 
     // Kill any interaction w/ the source
     close_source();
-
-    /* Set errors as quiet after the first one */
-    quiet_errors = 1;
 
     set_int_source_running(false);
 


### PR DESCRIPTION
Since commit 7ad14b75b7813640ccdd22860a386a9702707fd7, an error is displayed only the first time, for example when loosing the connection with a remote capture.

This seems a bit strange so remove this limitation.

Moreover, errors are not displayed after the source is closed since commit 3bab497c7a70610f0942c14feb2e5cb6ff0d6af4.

This is an issue if the source is closed and then re-opened so remove also this limitation.

Both changes should fix #198

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>