### PR TITLE
capture_*/Makefile.in: fix install when cross-compiling

### DIFF
--- a/capture_freaklabs_zigbee/Makefile.in
+++ b/capture_freaklabs_zigbee/Makefile.in
@@ -19,7 +19,7 @@ $(DATASOURCE_NAME)/kismetexternal/%_pb2.py: $(PROTOBUF_DIR)/%.proto
 	sed -i -E 's/^import kismet_/from . import kismet_/' $@
 
 install:
-	$(PYTHON) setup.py install
+	$(PYTHON) setup.py install --root="/$(DESTDIR)" --prefix="$(prefix)"
 
 clean:
 	@-$(PYTHON) setup.py clean

--- a/capture_sdr_rtl433/Makefile.in
+++ b/capture_sdr_rtl433/Makefile.in
@@ -19,7 +19,7 @@ $(DATASOURCE_NAME)/kismetexternal/%_pb2.py: $(PROTOBUF_DIR)/%.proto
 	sed -i -E 's/^import kismet_/from . import kismet_/' $@
 
 install:
-	$(PYTHON) setup.py install
+	$(PYTHON) setup.py install --root="/$(DESTDIR)" --prefix="$(prefix)"
 
 clean:
 	@-$(PYTHON) setup.py clean

--- a/capture_sdr_rtladsb/Makefile.in
+++ b/capture_sdr_rtladsb/Makefile.in
@@ -19,7 +19,7 @@ $(DATASOURCE_NAME)/kismetexternal/%_pb2.py: $(PROTOBUF_DIR)/%.proto
 	sed -i -E 's/^import kismet_/from . import kismet_/' $@
 
 install:
-	$(PYTHON) setup.py install
+	$(PYTHON) setup.py install --root="/$(DESTDIR)" --prefix="$(prefix)"
 
 clean:
 	@-$(PYTHON) setup.py clean

--- a/capture_sdr_rtlamr/Makefile.in
+++ b/capture_sdr_rtlamr/Makefile.in
@@ -19,7 +19,7 @@ $(DATASOURCE_NAME)/kismetexternal/%_pb2.py: $(PROTOBUF_DIR)/%.proto
 	sed -i -E 's/^import kismet_/from . import kismet_/' $@
 
 install:
-	$(PYTHON) setup.py install
+	$(PYTHON) setup.py install --root="/$(DESTDIR)" --prefix="$(prefix)"
 
 clean:
 	@-$(PYTHON) setup.py clean


### PR DESCRIPTION
Pass -`-root="/$(DESTDIR)" --prefix="$(prefix)"` to setup.py to fix install when cross-compiling.

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>