### PR TITLE
Do not require protobuf

### DIFF
--- a/configure
+++ b/configure
@@ -10895,7 +10895,8 @@ $as_echo "no" >&6; }
 	fi
 fi
 
-# We always need proto-c because it's required to compile the python protobuf instances
+if test "$caponly" = 0; then
+    # We only *require* protobuf for C++
 
 pkg_failed=no
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for protobuf" >&5
@@ -10987,9 +10988,9 @@ else
 $as_echo "yes" >&6; }
 	have_protobuf_pkg=yes
 fi
-if test x"$have_protobuf_pkg" != "xyes"; then
-    as_fn_error $? "missing google libprotobuf" "$LINENO" 5
-fi
+    if test x"$have_protobuf_pkg" != "xyes"; then
+        as_fn_error $? "missing google libprotobuf" "$LINENO" 5
+    fi
 
 
 # Check whether --with-protoc was given.
@@ -10998,9 +10999,9 @@ if test "${with_protoc+set}" = set; then :
 fi
 
 
-if test x"$with_protoc" == "x"; then
-    PROTOCBIN=protoc
-    # Extract the first word of "protoc", so it can be a program name with args.
+    if test x"$with_protoc" == "x"; then
+        PROTOCBIN=protoc
+        # Extract the first word of "protoc", so it can be a program name with args.
 set dummy protoc; ac_word=$2
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
 $as_echo_n "checking for $ac_word... " >&6; }
@@ -11037,19 +11038,20 @@ $as_echo "no" >&6; }
 fi
 
 
-    if test x"$protoc" != x"yes"; then
-        as_fn_error $? "missing google libprotobuf protoc compiler" "$LINENO" 5
+        if test x"$protoc" != x"yes"; then
+            as_fn_error $? "missing google libprotobuf protoc compiler" "$LINENO" 5
+        fi
+    else
+        PROTOCBIN=$with_protoc
     fi
-else
-    PROTOCBIN=$with_protoc
-fi
 
-PROTOLIBS=`pkg-config --libs ${PROTOBUF}`
-PROTOCFLAGS=`pkg-config --cflags ${PROTOBUF}`
+    PROTOLIBS=`pkg-config --libs ${PROTOBUF}`
+    PROTOCFLAGS=`pkg-config --cflags ${PROTOBUF}`
 
-# Enable the C++ targets
-PROTOBUF_CPP_O_TARGET='$(PROTOBUF_CPP_O)'
-PROTOBUF_CPP_H_TARGET='$(PROTOBUF_CPP_H)'
+    # Enable the C++ targets
+    PROTOBUF_CPP_O_TARGET='$(PROTOBUF_CPP_O)'
+    PROTOBUF_CPP_H_TARGET='$(PROTOBUF_CPP_H)'
+fi  # caponly
 
 # We need protobuf-c all the time
 

--- a/configure.ac
+++ b/configure.ac
@@ -1074,32 +1074,34 @@ AC_SUBST(pcap)
 
 PKG_PROG_PKG_CONFIG
 
-# We always need proto-c because it's required to compile the python protobuf instances
-PKG_CHECK_MODULES([protobuf], [${PROTOBUF}], have_protobuf_pkg=yes)
-if test x"$have_protobuf_pkg" != "xyes"; then
-    AC_MSG_ERROR([missing google libprotobuf])
-fi
-
-AC_ARG_WITH(protoc,
-	[  --with-protoc[=PATH]     Custom location of the protoc protobuf compiler],
-    [ ])
-
-if test x"$with_protoc" == "x"; then
-    PROTOCBIN=protoc
-    AC_CHECK_PROG(protoc, [protoc], yes)
-    if test x"$protoc" != x"yes"; then
-        AC_MSG_ERROR([missing google libprotobuf protoc compiler])
+if test "$caponly" = 0; then
+    # We only *require* protobuf for C++
+    PKG_CHECK_MODULES([protobuf], [${PROTOBUF}], have_protobuf_pkg=yes)
+    if test x"$have_protobuf_pkg" != "xyes"; then
+        AC_MSG_ERROR([missing google libprotobuf])
     fi
-else
-    PROTOCBIN=$with_protoc
-fi
+    
+    AC_ARG_WITH(protoc,
+    	[  --with-protoc[=PATH]     Custom location of the protoc protobuf compiler],
+        [ ])
+    
+    if test x"$with_protoc" == "x"; then
+        PROTOCBIN=protoc
+        AC_CHECK_PROG(protoc, [protoc], yes)
+        if test x"$protoc" != x"yes"; then
+            AC_MSG_ERROR([missing google libprotobuf protoc compiler])
+        fi
+    else
+        PROTOCBIN=$with_protoc
+    fi
+    
+    PROTOLIBS=`pkg-config --libs ${PROTOBUF}`
+    PROTOCFLAGS=`pkg-config --cflags ${PROTOBUF}`
 
-PROTOLIBS=`pkg-config --libs ${PROTOBUF}`
-PROTOCFLAGS=`pkg-config --cflags ${PROTOBUF}`
-
-# Enable the C++ targets
-PROTOBUF_CPP_O_TARGET='$(PROTOBUF_CPP_O)'
-PROTOBUF_CPP_H_TARGET='$(PROTOBUF_CPP_H)'
+    # Enable the C++ targets
+    PROTOBUF_CPP_O_TARGET='$(PROTOBUF_CPP_O)'
+    PROTOBUF_CPP_H_TARGET='$(PROTOBUF_CPP_H)'
+fi  # caponly
 
 # We need protobuf-c all the time
 PKG_CHECK_MODULES([libprotobufc], [libprotobuf-c], have_protobufc_pkg=yes, have_protobufc_pkg=no)

--- a/configure.ac
+++ b/configure.ac
@@ -1074,8 +1074,8 @@ AC_SUBST(pcap)
 
 PKG_PROG_PKG_CONFIG
 
-if test "$caponly" = 0; then
-    # We only *require* protobuf for C++
+if test "$caponly" = 0 || test "$want_python" = "yes"; then
+    # We only *require* protobuf for C++ and python
     PKG_CHECK_MODULES([protobuf], [${PROTOBUF}], have_protobuf_pkg=yes)
     if test x"$have_protobuf_pkg" != "xyes"; then
         AC_MSG_ERROR([missing google libprotobuf])


### PR DESCRIPTION
This reverts commit 197730f. Indeed, protoc is only required for C++ (server) and python. This will still allow the other kismet capture binaries to be built on embedded platforms not supported by protobuf.

Instead, protobuf will be required  if python is wanted.

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>