### PR TITLE
alertracker.cc: do not return server timestamp with {ek,it}json

### DIFF
--- a/alertracker.cc
+++ b/alertracker.cc
@@ -701,7 +701,10 @@ void alert_tracker::httpd_create_stream_response(
             std::stringstream ss(tokenurl[3]);
             ss >> since_time;
 
-            wrap = true;
+            // do not wrap with ekjson or itjson
+            if (tokenurl[4] != "alerts.ekjson" && tokenurl[4] != "alerts.itjson") {
+                wrap = true;
+            }
         }
     }
 


### PR DESCRIPTION
Do not return server timestamp when using the timestamp alerts API with
ekjson or itjson endpoints as those endpoints only work with vectors.

Fix #186
Fix https://github.com/kismetwireless/python-kismet-rest/issues/5

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>