### PR TITLE
Fix ipdata

### DIFF
--- a/endian_magic.h
+++ b/endian_magic.h
@@ -126,7 +126,7 @@
 	((uint32_t)((uint32_t)*((const uint8_t *)(x) + 1) << 24 | \
 	((uint32_t)((uint32_t)*((const uint8_t *)(x) + 0) << 16 | \
 	((uint32_t)((uint32_t)*((const uint8_t *)(x) + 3) << 8 | \
- 	(uint32_t)*((const uint8_t *)(x) + 2))) 
+ 	(uint32_t)*((const uint8_t *)(x) + 2)))))))
 
 #define kis_extractLE64(x) \
 	((uint64_t)((uint64_t)*((const uint8_t *)(x) + 1) << 56 | \
@@ -136,7 +136,7 @@
 	((uint64_t)((uint64_t)*((const uint8_t *)(x) + 5) << 24 | \
 	((uint64_t)((uint64_t)*((const uint8_t *)(x) + 4) << 16 | \
 	((uint64_t)((uint64_t)*((const uint8_t *)(x) + 7) << 8 | \
- 	(uint64_t)*((const uint8_t *)(x) + 6))) 
+ 	(uint64_t)*((const uint8_t *)(x) + 6)))))))))))))))
 
 #define kis_extractBE16(x) \
 	((uint16_t)((uint16_t)*((const uint8_t *)(x) + 0) << 8 | \
@@ -146,7 +146,7 @@
 	((uint32_t)((uint32_t)*((const uint8_t *)(x) + 0) << 24 | \
 	((uint32_t)((uint32_t)*((const uint8_t *)(x) + 1) << 16 | \
 	((uint32_t)((uint32_t)*((const uint8_t *)(x) + 2) << 8 | \
- 	(uint32_t)*((const uint8_t *)(x) + 3))) 
+ 	(uint32_t)*((const uint8_t *)(x) + 3)))))))
 
 #define kis_extractBE64(x) \
 	((uint64_t)((uint64_t)*((const uint8_t *)(x) + 0) << 56 | \
@@ -156,7 +156,7 @@
 	((uint64_t)((uint64_t)*((const uint8_t *)(x) + 4) << 24 | \
 	((uint64_t)((uint64_t)*((const uint8_t *)(x) + 5) << 16 | \
 	((uint64_t)((uint64_t)*((const uint8_t *)(x) + 6) << 8 | \
- 	(uint64_t)*((const uint8_t *)(x) + 7))) 
+ 	(uint64_t)*((const uint8_t *)(x) + 7)))))))))))))))
 
 #endif
-
+	

--- a/kis_dissector_ipdata.cc
+++ b/kis_dissector_ipdata.cc
@@ -214,6 +214,7 @@ std::string MDNS_Fetchname(kis_datachunk *chunk, unsigned int baseofft,
 
 int kis_dissector_ip_data::handle_packet(kis_packet *in_pack) {
 	kis_data_packinfo *datainfo = NULL;
+	uint32_t addr;
 
 	if (in_pack->error)
 		return 0;
@@ -309,8 +310,8 @@ int kis_dissector_ip_data::handle_packet(kis_packet *in_pack) {
 		// frame...
 		
 		datainfo->proto = proto_arp;
-		memcpy(&(datainfo->ip_source_addr.s_addr),
-			   &(chunk->data[ARP_OFFSET + 16]), 4);
+		memcpy(&addr, &(chunk->data[ARP_OFFSET + 16]), 4);
+		datainfo->ip_source_addr.s_addr = kis_hton32(addr);
 		in_pack->insert(pack_comp_basicdata, datainfo);
 		return 1;
 	}
@@ -321,15 +322,16 @@ int kis_dissector_ip_data::handle_packet(kis_packet *in_pack) {
 			   UDP_SIGNATURE, sizeof(UDP_SIGNATURE)) == 0) {
 
 		// UDP frame...
+		datainfo->proto = proto_udp;
 		datainfo->ip_source_port = 
 			kis_ntoh16(kis_extract16(&(chunk->data[UDP_OFFSET])));
 		datainfo->ip_dest_port = 
 			kis_ntoh16(kis_extract16(&(chunk->data[UDP_OFFSET + 2])));
 
-		memcpy(&(datainfo->ip_source_addr.s_addr),
-			   &(chunk->data[IP_OFFSET + 3]), 4);
-		memcpy(&(datainfo->ip_dest_addr.s_addr),
-			   &(chunk->data[IP_OFFSET + 7]), 4);
+		memcpy(&addr, &(chunk->data[IP_OFFSET + 3]), 4);
+		datainfo->ip_source_addr.s_addr = kis_hton32(addr);
+		memcpy(&addr, &(chunk->data[IP_OFFSET + 7]), 4);
+		datainfo->ip_dest_addr.s_addr = kis_hton32(addr);
 
 #if 0
 		if (datainfo->ip_source_port == IAPP_PORT &&
@@ -467,21 +469,21 @@ int kis_dissector_ip_data::handle_packet(kis_packet *in_pack) {
 					return 0;
 				}
 
-				memcpy(&(datainfo->ip_dest_addr.s_addr), 
-					   &(chunk->data[DHCPD_OFFSET + 28]), 4);
+				memcpy(&addr, &(chunk->data[DHCPD_OFFSET + 28]), 4);
+				datainfo->ip_dest_addr.s_addr = kis_hton32(addr);
 
 				if (dhcp_tag_map.find(1) != dhcp_tag_map.end() &&
 					dhcp_tag_map[1].size() != 0) {
 
-					memcpy(&(datainfo->ip_netmask_addr.s_addr), 
-						   &(chunk->data[dhcp_tag_map[1][0] + 1]), 4);
+					memcpy(&addr, &(chunk->data[dhcp_tag_map[1][0] + 1]), 4);
+					datainfo->ip_netmask_addr.s_addr = kis_hton32(addr);
 				}
 
 				if (dhcp_tag_map.find(3) != dhcp_tag_map.end() &&
 					dhcp_tag_map[3].size() != 0) {
 
-					memcpy(&(datainfo->ip_gateway_addr.s_addr), 
-						   &(chunk->data[dhcp_tag_map[3][0] + 1]), 4);
+					memcpy(&addr, &(chunk->data[dhcp_tag_map[3][0] + 1]), 4);
+					datainfo->ip_gateway_addr.s_addr = kis_hton32(addr);
 				}
 			}
 		}
@@ -684,10 +686,10 @@ mdns_end:
 		datainfo->ip_dest_port = 
 			kis_ntoh16(kis_extract16(&(chunk->data[TCP_OFFSET + 2])));
 
-		memcpy(&(datainfo->ip_source_addr.s_addr),
-			   &(chunk->data[IP_OFFSET + 3]), 4);
-		memcpy(&(datainfo->ip_dest_addr.s_addr),
-			   &(chunk->data[IP_OFFSET + 7]), 4);
+		memcpy(&addr, &(chunk->data[IP_OFFSET + 3]), 4);
+		datainfo->ip_source_addr.s_addr = kis_hton32(addr);
+		memcpy(&addr, &(chunk->data[IP_OFFSET + 7]), 4);
+		datainfo->ip_dest_addr.s_addr = kis_hton32(addr);
 
 		datainfo->proto = proto_tcp;
 


### PR DESCRIPTION
Fill the ipdata structure based on information retrieved from ARP, DHCP,
UDP or TCP

The IPv4 addresses are converted to network byte order.

It should be noted that the IP address is still not currently displayed
in the Web UI as I don't know how to convert it to a string

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>