### PR TITLE
Bluetooth: Do not return an error when no RFKILL file is found.

### DIFF
--- a/capture_linux_bluetooth/linux_bt_rfkill.c
+++ b/capture_linux_bluetooth/linux_bt_rfkill.c
@@ -71,7 +71,7 @@ int linux_sys_get_bt_rfkill(const char *interface, unsigned int rfkill_type) {
         }
     }
 
-    return -1;
+    return 0;
 }
 
 int linux_sys_clear_bt_rfkill(const char *interface) {


### PR DESCRIPTION
On OpenWRT, HCI devices do not seem to contain an RFKILL directory/file, so this function will result in
broken Bluetooth sources.