### PR TITLE
Make available more WPS information

### DIFF
--- a/dot11_parsers/dot11_ie_221_ms_wps.cc
+++ b/dot11_parsers/dot11_ie_221_ms_wps.cc
@@ -58,8 +58,20 @@ void dot11_ie_221_ms_wps::wps_de_sub_element::parse(std::shared_ptr<kaitai::kstr
         std::shared_ptr<wps_de_sub_string> s(new wps_de_sub_string());
         s->parse(m_wps_de_content_data_stream);
         m_sub_element = s;
+    } else if (wps_de_type() == wps_de_version) {
+        std::shared_ptr<wps_de_sub_version> s(new wps_de_sub_version());
+        s->parse(m_wps_de_content_data_stream);
+        m_sub_element = s;
     } else if (wps_de_type() == wps_de_state) {
         std::shared_ptr<wps_de_sub_state> s(new wps_de_sub_state());
+        s->parse(m_wps_de_content_data_stream);
+        m_sub_element = s;
+    } else if (wps_de_type() == wps_de_ap_setup) {
+        std::shared_ptr<wps_de_sub_ap_setup> s(new wps_de_sub_ap_setup());
+        s->parse(m_wps_de_content_data_stream);
+        m_sub_element = s;
+    } else if (wps_de_type() == wps_de_config_methods) {
+        std::shared_ptr<wps_de_sub_config_methods> s(new wps_de_sub_config_methods());
         s->parse(m_wps_de_content_data_stream);
         m_sub_element = s;
     } else if (wps_de_type() == wps_de_uuid_e) {
@@ -108,6 +120,10 @@ void dot11_ie_221_ms_wps::wps_de_sub_element::wps_de_sub_version::parse(std::sha
 
 void dot11_ie_221_ms_wps::wps_de_sub_element::wps_de_sub_ap_setup::parse(std::shared_ptr<kaitai::kstream> p_io) {
     m_ap_setup_locked = p_io->read_u1();
+}
+
+void dot11_ie_221_ms_wps::wps_de_sub_element::wps_de_sub_config_methods::parse(std::shared_ptr<kaitai::kstream> p_io) {
+    m_config_methods = p_io->read_u2be();
 }
 
 void dot11_ie_221_ms_wps::wps_de_sub_element::wps_de_sub_generic::parse(std::shared_ptr<kaitai::kstream> p_io) {

--- a/dot11_parsers/dot11_ie_221_ms_wps.h
+++ b/dot11_parsers/dot11_ie_221_ms_wps.h
@@ -74,9 +74,11 @@ public:
         class wps_de_sub_version;
         class wps_de_sub_primary_type;
         class wps_de_sub_ap_setup;
+        class wps_de_sub_config_methods;
         class wps_de_sub_generic;
 
         enum wps_de_type_e {
+            wps_de_config_methods = 0x1008,
             wps_de_device_name = 0x1011,
             wps_de_manuf = 0x1021,
             wps_de_model = 0x1023,
@@ -157,9 +159,27 @@ public:
             return NULL;
         }
 
+       std::shared_ptr<wps_de_sub_version> sub_element_version() const {
+            if (wps_de_type() == wps_de_version)
+                return std::static_pointer_cast<wps_de_sub_version>(sub_element());
+            return NULL;
+        }
+
         std::shared_ptr<wps_de_sub_state> sub_element_state() const {
             if (wps_de_type() == wps_de_state)
                 return std::static_pointer_cast<wps_de_sub_state>(sub_element());
+            return NULL;
+        }
+
+        std::shared_ptr<wps_de_sub_ap_setup> sub_element_ap_setup() const {
+            if (wps_de_type() == wps_de_ap_setup)
+                return std::static_pointer_cast<wps_de_sub_ap_setup>(sub_element());
+            return NULL;
+        }
+
+        std::shared_ptr<wps_de_sub_config_methods> sub_element_config_methods() const {
+            if (wps_de_type() == wps_de_config_methods)
+                return std::static_pointer_cast<wps_de_sub_config_methods>(sub_element());
             return NULL;
         }
 
@@ -340,6 +360,21 @@ public:
 
         protected:
             uint8_t m_ap_setup_locked;
+        };
+
+        class wps_de_sub_config_methods : public wps_de_sub_common {
+        public:
+            wps_de_sub_config_methods() { }
+            virtual ~wps_de_sub_config_methods() { }
+
+            virtual void parse(std::shared_ptr<kaitai::kstream> p_io);
+
+            constexpr17 uint16_t wps_config_methods() const {
+                return m_config_methods;
+            }
+
+        protected:
+            uint16_t m_config_methods;
         };
 
         class wps_de_sub_generic : public wps_de_sub_common {

--- a/phy_80211.cc
+++ b/phy_80211.cc
@@ -2692,7 +2692,11 @@ void kis_80211_phy::handle_ssid(std::shared_ptr<kis_tracked_device_base> basedev
             ssid->clear_dot11d_vec();
     }
 
+    ssid->set_wps_version(dot11info->wps_version);
     ssid->set_wps_state(dot11info->wps);
+    ssid->set_wps_config_methods(dot11info->wps_config_methods);
+    if (dot11info->wps_device_name != "")
+        ssid->set_wps_device_name(dot11info->wps_device_name);
     if (dot11info->wps_manuf != "")
         ssid->set_wps_manuf(dot11info->wps_manuf);
     if (dot11info->wps_model_name != "") {
@@ -2826,7 +2830,9 @@ void kis_80211_phy::handle_probed_ssid(std::shared_ptr<kis_tracked_device_base> 
         // Update the crypt set if any
         probessid->set_crypt_set(dot11info->cryptset);
 
+        probessid->set_wps_version(dot11info->wps_version);
         probessid->set_wps_state(dot11info->wps);
+        probessid->set_wps_config_methods(dot11info->wps_config_methods);
         if (dot11info->wps_manuf != "")
             probessid->set_wps_manuf(dot11info->wps_manuf);
         if (dot11info->wps_model_name != "") {

--- a/phy_80211.h
+++ b/phy_80211.h
@@ -143,7 +143,9 @@ class dot11_packinfo : public packet_component {
 
             dot11d_country = "";
 
+            wps_version = 0; 
             wps = DOT11_WPS_NO_WPS;
+            wps_config_methods = 0;
             wps_manuf = "";
             wps_device_name = "";
             wps_model_name = "";
@@ -236,7 +238,9 @@ class dot11_packinfo : public packet_component {
         std::vector<dot11_packinfo_dot11d_entry> dot11d_vec;
 
         // WPS information
+        uint8_t wps_version;
         uint8_t wps;
+        uint16_t wps_config_methods;
         // The field below is useful because some APs use
         // a MAC address with 'Unknown' OUI but will
         // tell their manufacturer in this field:

--- a/phy_80211_components.cc
+++ b/phy_80211_components.cc
@@ -167,8 +167,13 @@ void dot11_probed_ssid::register_fields() {
         register_dynamic_field("dot11.probedssid.ie_tag_list",
                 "802.11 IE tag list in beacon", &ie_tag_list);
 
+    wps_version_id =
+        register_dynamic_field("dot11.probedssid.wps_version", "WPS version", &wps_version);
     wps_state_id =
         register_dynamic_field("dot11.probedssid.wps_state", "WPS state bitfield", &wps_state);
+    wps_config_methods_id =
+        register_dynamic_field("dot11.probedssid.wps_config_methods", "WPS config methods bitfield",
+            &wps_config_methods);
     wps_manuf_id =
         register_dynamic_field("dot11.probedssid.wps_manuf", "WPS manufacturer", &wps_manuf);
     wps_device_name_id =
@@ -242,8 +247,13 @@ void dot11_advertised_ssid::register_fields() {
                 tracker_element_factory<dot11_11d_tracked_range_info>(0),
                 "dot11d entry");
 
+    wps_version_id =
+        register_dynamic_field("dot11.advertisedssid.wps_version", "WPS version", &wps_version);
     wps_state_id =
         register_dynamic_field("dot11.advertisedssid.wps_state", "bitfield wps state", &wps_state);
+    wps_config_methods_id =
+        register_dynamic_field("dot11.advertisedssid.wps_config_methods",
+                "bitfield wps config methods", &wps_config_methods);
     wps_manuf_id =
         register_dynamic_field("dot11.advertisedssid.wps_manuf", "WPS manufacturer", &wps_manuf);
     wps_device_name_id =

--- a/phy_80211_components.h
+++ b/phy_80211_components.h
@@ -439,7 +439,11 @@ public:
 
             __ImportId(ie_tag_list_id, p);
 
+            __ImportId(wps_version_id, p);
+
             __ImportId(wps_state_id, p);
+
+            __ImportId(wps_config_methods_id, p);
 
             __ImportId(wps_manuf_id, p);
 
@@ -483,7 +487,9 @@ public:
 
     __ProxyDynamicTrackable(ie_tag_list, tracker_element_vector_double, ie_tag_list, ie_tag_list_id);
 
+    __ProxyDynamic(wps_version, uint8_t, uint8_t, uint8_t, wps_version, wps_version_id);
     __ProxyDynamic(wps_state, uint32_t, uint32_t, uint32_t, wps_state, wps_state_id);
+    __ProxyDynamic(wps_config_methods, uint16_t, uint16_t, uint16_t, wps_config_methods, wps_config_methods_id);
     __ProxyDynamic(wps_manuf, std::string, std::string, std::string, wps_manuf, wps_manuf_id);
     __ProxyDynamic(wps_device_name, std::string, std::string, std::string, wps_device_name, wps_device_name_id);
     __ProxyDynamic(wps_model_name, std::string, std::string, std::string, wps_model_name, wps_model_name_id);
@@ -514,8 +520,14 @@ protected:
     int ie_tag_list_id;
 
     // WPS components
+    std::shared_ptr<tracker_element_uint8> wps_version;
+    int wps_version_id;
+
     std::shared_ptr<tracker_element_uint32> wps_state;
     int wps_state_id;
+
+    std::shared_ptr<tracker_element_uint16> wps_config_methods;
+    int wps_config_methods_id;
 
     std::shared_ptr<tracker_element_string> wps_manuf;
     int wps_manuf_id;
@@ -600,7 +612,9 @@ public:
             __ImportId(dot11d_vec_id, p);
             __ImportId(dot11d_country_entry_id, p);
 
+            __ImportId(wps_version_id, p);
             __ImportId(wps_state_id, p);
+            __ImportId(wps_config_methods_id, p);
             __ImportId(wps_manuf_id, p);
             __ImportId(wps_device_name_id, p);
             __ImportId(wps_model_name_id, p);
@@ -681,7 +695,10 @@ public:
     __ProxyDynamicTrackable(dot11d_vec, tracker_element_vector, dot11d_vec, dot11d_vec_id);
     void set_dot11d_vec(std::vector<dot11_packinfo_dot11d_entry> vec);
 
+    __ProxyDynamic(wps_version, uint8_t, uint8_t, uint8_t, wps_version, wps_version_id);
     __ProxyDynamic(wps_state, uint32_t, uint32_t, uint32_t, wps_state, wps_state_id);
+    __ProxyDynamic(wps_config_methods, uint16_t, uint16_t, uint16_t, wps_config_methods,
+            wps_config_methods_id);
     __ProxyDynamic(wps_manuf, std::string, std::string, std::string, wps_manuf, wps_manuf_id);
     __ProxyDynamic(wps_device_name, std::string, std::string, std::string, wps_device_name, 
             wps_device_name_id);
@@ -783,8 +800,14 @@ protected:
     int dot11d_country_entry_id;
 
     // WPS components
+    std::shared_ptr<tracker_element_uint8> wps_version;
+    int wps_version_id;
+
     std::shared_ptr<tracker_element_uint32> wps_state;
     int wps_state_id;
+
+    std::shared_ptr<tracker_element_uint16> wps_config_methods;
+    int wps_config_methods_id;
 
     std::shared_ptr<tracker_element_string> wps_manuf;
     int wps_manuf_id;

--- a/phy_80211_dissectors.cc
+++ b/phy_80211_dissectors.cc
@@ -2154,6 +2154,12 @@ int kis_80211_phy::packet_dot11_ie_dissector(kis_packet *in_pack, dot11_packinfo
                     wps->parse(vendor->vendor_tag_stream());
 
                     for (auto wpselem : *(wps->wps_elements())) {
+                        auto version = wpselem->sub_element_version();
+                        if (version != NULL) {
+                            packinfo->wps_version = version->version();
+                            continue;
+                        }
+
                         auto state = wpselem->sub_element_state();
                         if (state != NULL) {
                             if (state->wps_state_configured()) {
@@ -2162,6 +2168,21 @@ int kis_80211_phy::packet_dot11_ie_dissector(kis_packet *in_pack, dot11_packinfo
                                 packinfo->wps |= DOT11_WPS_NOT_CONFIGURED;
                             }
 
+                            continue;
+                        }
+
+                        auto ap_setup = wpselem->sub_element_ap_setup();
+                        if (ap_setup != NULL) {
+                            if (ap_setup->ap_setup_locked()) {
+                                packinfo->wps |= DOT11_WPS_LOCKED;
+                            }
+
+                            continue;
+                        }
+
+                        auto config_methods = wpselem->sub_element_config_methods();
+                        if (config_methods != NULL) {
+                            packinfo->wps_config_methods = config_methods->wps_config_methods();
                             continue;
                         }
 


### PR DESCRIPTION
Make the following WPS information available to upper level:
 - WPS version
 - WPS device name
 - WPS Locked state
 - WPS Config Methods bitfield (Display, NFC, PBC ...)

This PR could be enhanced by printing this information in the Web UI:
 - WPS version: 1.0 for 0x10 or 2.0 for 0x20
 - WPS state: Configured & locked, Unconfigured & locked, etc.
 - WPS Config Methods

Signed-off-by: Fabrice Fontaine <fabrice.fontaine@orange.com>