### PR TITLE
Document '-c' option in cli usage message

### DIFF
--- a/kismet_server.cc
+++ b/kismet_server.cc
@@ -307,10 +307,12 @@ int usage(char *argv) {
 
     printf(" *** Generic Options ***\n");
     printf(" -v, --version                Show version\n"
+           " -h  --help                   Display this help message\n"
            "     --no-console-wrapper     Disable server console wrapper\n"
            "     --no-ncurses-wrapper     Disable server console wrapper\n"
            "     --debug                  Disable the console wrapper and the crash\n"
            "                              handling functions, for debugging\n"
+           " -c <datasource>              Use the specified datasource\n"
            " -f, --config-file <file>     Use alternate configuration file\n"
            "     --no-line-wrap           Turn off linewrapping of output\n"
            "                              (for grep, speed, etc)\n"


### PR DESCRIPTION
I always have to dig the documentation to find out how to replay a .kismet log db.

This is an attempt to fix that by documenting that option in the usage output of kismet.