### PR TITLE
macaddr.h: more tweak to mac addr state init

### DIFF
--- a/macaddr.h
+++ b/macaddr.h
@@ -175,7 +175,10 @@ struct mac_addr {
     constexpr mac_addr(const mac_addr& in) :
         longmac{in.longmac},
         maskbits{in.maskbits},
-        state {in.state} { }
+        state {
+            .len = in.state.len,
+            .error = in.state.error
+        } { }
 
     mac_addr(const char *in) {
         string2long(in);


### PR DESCRIPTION
As already done in c40580fdc173079d44d9d874de0593a6290729cd, tweak more mac addr state initialization for some compiler versions to avoid the following build failure with gcc 4.8:

```
./macaddr.h: In copy constructor 'constexpr mac_addr::mac_addr(const mac_addr&)':
./macaddr.h:175:24: error: cannot convert 'const mac_addr::<anonymous struct>' to 'unsigned int' in initialization
         state {in.state} { }
                        ^
./macaddr.h:175:28: error: uninitialized member 'mac_addr::state' in 'constexpr' constructor
         state {in.state} { }
                            ^
```

Fixes:
 - http://autobuild.buildroot.org/results/23315ab69eeb26ef8aca9a24e6265504717040e6

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>