### PR TITLE
log_tools/kismetdb_statistics.cc: use strftime

### DIFF
--- a/log_tools/kismetdb_statistics.cc
+++ b/log_tools/kismetdb_statistics.cc
@@ -202,9 +202,12 @@ int main(int argc, char *argv[]) {
             root["device_max_time"] = (uint64_t) max_time;
         } else {
             fmt::print("  Devices: {}\n", n_total_devices);
+            char min_tmstr[256];
+            char max_tmstr[256];
+            strftime(min_tmstr, 255, "%Y-%m-%d %H:%M:%S", &min_tm);
+            strftime(max_tmstr, 255, "%Y-%m-%d %H:%M:%S", &max_tm);
             fmt::print("  Devices seen between: {} ({}) to {} ({})\n",
-                    std::put_time(&min_tm, "%Y-%m-%d %H:%M:%S"), min_time,
-                    std::put_time(&max_tm, "%Y-%m-%d %H:%M:%S"), max_time);
+                    min_tmstr, min_time, max_tmstr, max_time);
         }
 
         auto n_sources_q = _SELECT(db, "datasources", {"count(*)"});


### PR DESCRIPTION
Building with gcc < 5 (e.g. gcc 4.8) raises the following build failure:

```
log_tools/kismetdb_statistics.cc: In function 'int main(int, char**)':
log_tools/kismetdb_statistics.cc:206:21: error: 'put_time' is not a member of 'std'
                     std::put_time(&min_tm, "%Y-%m-%d %H:%M:%S"), min_time,
                     ^
log_tools/kismetdb_statistics.cc:207:21: error: 'put_time' is not a member of 'std'
                     std::put_time(&max_tm, "%Y-%m-%d %H:%M:%S"), max_time);
                     ^
```

This issue is due to a gcc bug (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=54354) which has been fixed in gcc 5. So replace std::put_time by strftime

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>