### PR TITLE
fix#331: Identificator for field "Wi-Fi (802.11)" / "Retried Data" was corrected

### DIFF
--- a/http_data/js/kismet.ui.dot11.js
+++ b/http_data/js/kismet.ui.dot11.js
@@ -673,7 +673,7 @@ kismet_ui.AddDeviceDetail("dot11", "Wi-Fi (802.11)", 0, {
                     help: "The amount of data transmitted by this device",
                 },
                 {
-                    field: "dot11.device/dot11.device.datasize.retry",
+                    field: "dot11.device/dot11.device.datasize_retry",
                     liveupdate: true,
                     title: "Retried Data",
                     draw: kismet_ui.RenderHumanSize,


### PR DESCRIPTION
see https://github.com/kismetwireless/kismet/issues/331