### PR TITLE
Add getter to read database values as time_t

### DIFF
--- a/sqlite3_cpp11.cc
+++ b/sqlite3_cpp11.cc
@@ -412,6 +412,11 @@ namespace kissqlite3 {
     }
 
     template<>
+    long long sqlite3_column_as(std::shared_ptr<sqlite3_stmt> stmt, unsigned int column) {
+        return (long long) sqlite3_column_int64(stmt.get(), column);
+    }
+
+    template<>
     unsigned long long sqlite3_column_as(std::shared_ptr<sqlite3_stmt> stmt, unsigned int column) {
         return (unsigned long long) sqlite3_column_int64(stmt.get(), column);
     }


### PR DESCRIPTION
On some platforms `time_t` is defined as `long long`. At the moment, the compilation of `sqlite3_column_as<time_t>(...)` fails on these systems because the appropriate getter is not defined:
```text
/src/kismet-2020-12-R3/log_tools/kismetdb_statistics.cc:193: undefined reference to `long long kissqlite3::sqlite3_column_as<long long>(std::shared_ptr<sqlite3_stmt>, unsigned int)'
```