### PR TITLE
boost/asio: Use eventfd() function with uClibc

### DIFF
--- a/boost/asio/detail/impl/eventfd_select_interrupter.ipp
+++ b/boost/asio/detail/impl/eventfd_select_interrupter.ipp
@@ -23,11 +23,11 @@
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <fcntl.h>
-#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 8
+#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 8 && !defined(__UCLIBC__)
 # include <asm/unistd.h>
-#else // __GLIBC__ == 2 && __GLIBC_MINOR__ < 8
+#else // __GLIBC__ == 2 && __GLIBC_MINOR__ < 8 && !defined(__UCLIBC__)
 # include <sys/eventfd.h>
-#endif // __GLIBC__ == 2 && __GLIBC_MINOR__ < 8
+#endif // __GLIBC__ == 2 && __GLIBC_MINOR__ < 8 && !defined(__UCLIBC__)
 #include <boost/asio/detail/cstdint.hpp>
 #include <boost/asio/detail/eventfd_select_interrupter.hpp>
 #include <boost/asio/detail/throw_error.hpp>
@@ -46,14 +46,14 @@ eventfd_select_interrupter::eventfd_select_interrupter()
 
 void eventfd_select_interrupter::open_descriptors()
 {
-#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 8
+#if __GLIBC__ == 2 && __GLIBC_MINOR__ < 8 && !defined(__UCLIBC__)
   write_descriptor_ = read_descriptor_ = syscall(__NR_eventfd, 0);
   if (read_descriptor_ != -1)
   {
     ::fcntl(read_descriptor_, F_SETFL, O_NONBLOCK);
     ::fcntl(read_descriptor_, F_SETFD, FD_CLOEXEC);
   }
-#else // __GLIBC__ == 2 && __GLIBC_MINOR__ < 8
+#else // __GLIBC__ == 2 && __GLIBC_MINOR__ < 8 && !defined(__UCLIBC__)
 # if defined(EFD_CLOEXEC) && defined(EFD_NONBLOCK)
   write_descriptor_ = read_descriptor_ =
     ::eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
@@ -70,7 +70,7 @@ void eventfd_select_interrupter::open_descriptors()
       ::fcntl(read_descriptor_, F_SETFD, FD_CLOEXEC);
     }
   }
-#endif // __GLIBC__ == 2 && __GLIBC_MINOR__ < 8
+#endif // __GLIBC__ == 2 && __GLIBC_MINOR__ < 8 && !defined(__UCLIBC__)
 
   if (read_descriptor_ == -1)
   {


### PR DESCRIPTION
Fix build with uclibc thanks to https://github.com/boostorg/asio/commit/b2ee39aee0b186c5bcabb051b7a536ab1517616a

Fixes:
 - http://autobuild.buildroot.org/results/1c2885d75219aabadbb66ab66fe0dc4b4346ff1e

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>