### PR TITLE
Killerbee and CC2531 updates for packet filtering

### DIFF
--- a/datasource_rz_killerbee.cc
+++ b/datasource_rz_killerbee.cc
@@ -29,7 +29,7 @@ void kis_datasource_rzkillerbee::handle_rx_packet(kis_packet *packet) {
 
         int rssi = rz_chunk->data[6];
         uint8_t channel = rz_chunk->data[5];
-	// We can make a valid payload from this much
+	    // We can make a valid payload from this much
         auto conv_buf_len = sizeof(_802_15_4_tap) + rz_payload_len;
         _802_15_4_tap *conv_header = reinterpret_cast<_802_15_4_tap *>(new uint8_t[conv_buf_len]);
         memset(conv_header, 0, conv_buf_len);
@@ -40,10 +40,11 @@ void kis_datasource_rzkillerbee::handle_rx_packet(kis_packet *packet) {
         conv_header->version = kis_htole16(0);// currently only one version
         conv_header->reserved = kis_htole16(0);// must be set to 0
 
-         // fcs setting
+        // Killerbee does include the FCS
+        // fcs setting
         conv_header->tlv[0].type = kis_htole16(0);
         conv_header->tlv[0].length = kis_htole16(1);
-        conv_header->tlv[0].value = kis_htole32(0);
+        conv_header->tlv[0].value = kis_htole32(1);
 
         // rssi
         conv_header->tlv[1].type = kis_htole16(10);

--- a/datasource_ti_cc_2531.cc
+++ b/datasource_ti_cc_2531.cc
@@ -51,7 +51,8 @@ void kis_datasource_ticc2531::handle_rx_packet(kis_packet *packet) {
     //uint8_t corr = fcs2 & 0x7f;
     uint8_t channel = cc_chunk->data[2];
 
-    if (crc_ok > 0) {
+    // check the CRC and check to see if the length, somehow matches the first byte of what should be the fcf
+    if (crc_ok > 0 && (cc_chunk->data[7] != cc_chunk->data[8])) {
 
         int rssi = (fcs1 + (int) pow(2, 7)) % (int) pow(2, 8) - (int) pow(2, 7) - 73;
 


### PR DESCRIPTION
rz killerbee includes the FCS so the TAP header needs to reflect that. CC2531 sending back bad valid packets. Trying to filter them