### PR TITLE
Fix typo in kismet.ui.alerts.js

### DIFF
--- a/http_data/js/kismet.ui.alerts.js
+++ b/http_data/js/kismet.ui.alerts.js
@@ -381,7 +381,7 @@ function InitializeAlertTable() {
         .on( 'mouseenter', 'td', function () {
             var alert_dt = alert_element.DataTable();
 
-            if (typeof(alert_dt.cell(this).index()) === 'Undefined')
+            if (typeof(alert_dt.cell(this).index()) === 'undefined')
                 return;
 
             var colIdx = alert_dt.cell(this).index().column;


### PR DESCRIPTION
Change 'Undefined' to the correct form: 'undefined'.