### PR TITLE
nrf_51822.h: fix build on sparc

### DIFF
--- a/capture_nrf_51822/nrf_51822.h
+++ b/capture_nrf_51822/nrf_51822.h
@@ -3,7 +3,6 @@
 #ifndef __NRF51822_H__
 #define __NRF51822_H__
 
-#ifdef __APPLE__
 #ifndef B9600
 #define B9600 9600
 #endif
@@ -57,7 +56,6 @@
 #endif
 #ifndef B4000000
 #define B4000000 4000000
-#endif
 #endif
 
 


### PR DESCRIPTION
apple is not the only target that miss some defines, for example build fails on sparc with:

```
capture_nrf_51822.c: In function 'get_baud':
capture_nrf_51822.c:80:16: error: 'B2500000' undeclared (first use in this function); did you mean 'B2000000'?
   80 |         return B2500000;
      |                ^~~~~~~~
      |                B2000000
capture_nrf_51822.c:80:16: note: each undeclared identifier is reported only once for each function it appears in
capture_nrf_51822.c:82:16: error: 'B3000000' undeclared (first use in this function); did you mean 'B2000000'?
   82 |         return B3000000;
      |                ^~~~~~~~
      |                B2000000
capture_nrf_51822.c:84:16: error: 'B3500000' undeclared (first use in this function); did you mean 'B500000'?
   84 |         return B3500000;
      |                ^~~~~~~~
      |                B500000
capture_nrf_51822.c:86:16: error: 'B4000000' undeclared (first use in this function); did you mean 'B2000000'?
   86 |         return B4000000;
      |                ^~~~~~~~
      |                B2000000
```

Fixes:
 - http://autobuild.buildroot.org/results/38f20816a654894c0625f00b1360c92fdc251e8b

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>