### PR TITLE
Bug fixes and enhancements to octalize/deoctalize

### DIFF
--- a/http_data/js/kismet.utils.js
+++ b/http_data/js/kismet.utils.js
@@ -440,36 +440,74 @@ exports.censorLocation = function(t) {
     }
 }
 
-exports.decoder = new TextDecoder();
+// utf8 to unicode converter (used below in deoctalize()).
+// "fatal: true" means that the converter will throw an 
+// exception if the input is not valid utf8.
+exports.decoder = new TextDecoder('utf8', {fatal: true});
 
-/* De-octalize an escaped string, and handle decoding it */
+/* De-octalize an escaped string, and decode it from utf8.
+ * If the input string contains anything unexpected (control
+ * characters, invalid values after the backslash, character
+ * sequences that are not valid utf8), return the input string.
+ * */
 exports.deoctalize = function(str) {
     var ret = new Array();
 
     for (var i = 0; i < str.length; i++) {
+        // If the current character is not a backslash, 
+        // do not modify it.
         if (str[i] != '\\') {
             ret.push(str.charCodeAt(i))
-        } else {
-            if (i + 3 < str.length &&
-                str[i + 1] >= '0' && str[i+1] <= '9' &&
-                str[i + 2] >= '0' && str[i+2] <= '9' &&
-                str[i + 3] >= '0' && str[i+3] <= '9') {
-
-                // console.log(str[i + 1] - '0', str[i + 2] - '0', str[i + 3] - '0')
+        // If the current character (a backslash) is followed by a 
+        // second backslash, remove the second backslash;
+        // no other modification needed.
+        } else if (i+1 < str.length && str[i+1] == '\\') {
+            ret.push(str.charCodeAt(i));
+            i++;
+        // If the backslash is followed by a 3-digit octal number
+        // in the range 000 to 377, replace the backslash and
+        // numerals by the corresponding octal character
+        } else if (i + 3 < str.length && str[i + 1] >= '0' && str[i+1] <= '3' &&
+                str[i + 2] >= '0' && str[i+2] <= '7' &&
+                str[i + 3] >= '0' && str[i+3] <= '7') {
 
                 var sum = 
                     ((str[i + 1] - '0') * 64) +
                     ((str[i + 2] - '0') * 8) +
                     ((str[i + 3] - '0'));
 
-                ret.push(sum);
+                // If the octal character is less than 32 decimal,
+                // then it is a control (non-printing) character.
+                // In this case, dont' de-octalize the input string;
+                // immediately return the entire input string.
+                if (sum < 32) {
+                    return str;
+                } else {
+                    ret.push(sum);
+                }
 
                 i += 3;
-            }
+	// This clause is reached only if a backslash was encountered,
+        // but the backslash was not followed by either another
+        // backslash or by 3 valid octal digits.  This means that
+        // the input string is not a valid octalized string, so we
+        // don't know how to de-octalize it.  In this case, return
+        // the input string.
+	} else {
+            return str;
         }
     }
 
-    return exports.decoder.decode(Uint8Array.from(ret))
+    try {
+        // Try to convert the de-octalized string from utf8 to
+        // unicode.
+        return exports.decoder.decode(Uint8Array.from(ret))
+    } catch(e) {
+        // The de-octalized string was not valid utf8, so we don't
+        // know how to convert it.  In this case, return the input
+        // string.
+        return str;
+    }
 }
 
 

--- a/util.cc
+++ b/util.cc
@@ -74,13 +74,17 @@
 
 // Convert a byte to an octal escape
 std::string d2oa(uint8_t n) {
-    std::string oa;
-    oa = "\\   ";
+    std::string oa = "\\000";
+
+	// make sure n is in the correct range
+	// (currently redundant, since n is declared a uint8, but
+	// protects against future changes)
+	n &= 0377;
 
     int i = 3;
-    while (n != 0 && i >= 0) {
-        oa[i--] =  '0' + ((n % 8) & 0xFF);
-        n = n / 8;
+    while (n > 0) {
+        oa[i--] =  '0' + (n & 07);
+        n >>= 3;
     }
 
     return oa;
@@ -96,9 +100,16 @@ std::string munge_to_printable(const char *in_data, unsigned int max, int nullte
 		if ((unsigned char) in_data[i] == 0 && nullterm == 1)
 			return ret.str();
 
-		if ((unsigned char) in_data[i] >= 32 && (unsigned char) in_data[i] <= 126) {
+		if (in_data[i] == '\\') {
+			// replace any input backslash by two backslashes,
+			// to distinguish it from a backslash created by
+			// the "octalize" process.
+			ret << "\\\\";
+		} else if ((unsigned char) in_data[i] >= 32 && (unsigned char) in_data[i] <= 126) {
             ret << in_data[i];
 		} else {
+			// "octalize" (convert to a printed octal representation)
+			// any characters outside the printable range
             ret << d2oa(in_data[i]);
 		}
 	}


### PR DESCRIPTION
Octalize (in util.cc):
1) Fixed bug, where spaces were sometimes output in place of zeroes (e.g. '\  7' instead of '\007').
2) When octalizing, replace each input backslash '\\' by two backslashes '\\\\', to avoid ambiguities between input backslashes and backslashes added by the octalizer.

Deoctalize (in kismet.utils.js):
1) Treat double backslash '\\\\' differently than backslash followed by octal numerals (per changes to octalizer).
2) In case of unexpected results of deoctalization (for instance, an unprintable control character, or an encoding that cannot be decoded as utf8), give up trying to deoctalize, and return the input octalized string.
Note: for an example of code that tries much harder than this to figure out which encoding was used, see the extensive comments at the head of nm_utils_ssid_to_utf8() in https://github.com/NetworkManager/NetworkManager/blob/main/src/libnm-core-impl/nm-utils.c
