### PR TITLE
Cut gps coord. lat/lon to 6 decimals

### DIFF
--- a/kis_wiglecsvlogfile.cc
+++ b/kis_wiglecsvlogfile.cc
@@ -298,7 +298,7 @@ int kis_wiglecsv_logfile::packet_handler(CHAINCALL_PARMS) {
 
         auto channel = frequency_to_wifi_channel(dev->get_frequency());
 
-        fmt::print(wigle->csvfile, "{},{},{},{},{},{},{:3.10f},{:3.10f},{:f},0,{}\n",
+        fmt::print(wigle->csvfile, "{},{},{},{},{},{},{:3.6f},{:3.6f},{:f},0,{}\n",
                 dev->get_macaddr(),
                 name,
                 crypt,


### PR DESCRIPTION
* More decimals does not mean better accuracy or precision but take space for nothing in csv file

See http://wiki.gis.com/wiki/index.php/Decimal_degrees

The 6th decimal of the gps longitude at the equator means roughly 0.11m (around 4 inches).
This is enough precision given the gps device is not able, most of the time, to deliver a better precision than that, when it's not around the meter.
So it does not make sense to store a position with sub-centimeter precision when the error is almost a meter.

I don't know what the wigle guys think about that...

May be 6 decimals is not enough ? 7 decimals could be another option but the 7th decimal is used to represent a centimeter ...