### PR TITLE
Fix Wi-Fi device/client classification

### DIFF
--- a/phy_80211.cc
+++ b/phy_80211.cc
@@ -1477,8 +1477,6 @@ int kis_80211_phy::packet_dot11_common_classifier(CHAINCALL_PARMS) {
 
             if (dot11info->bssid_dev != nullptr) {
                 dot11info->source_dot11->set_last_bssid(dot11info->bssid_dev->get_macaddr());
-            } else {
-                dot11info->source_dot11->set_last_bssid(mac_addr());
             }
 
             if (dot11info->channel != "0" && dot11info->channel != "") {
@@ -1533,8 +1531,9 @@ int kis_80211_phy::packet_dot11_common_classifier(CHAINCALL_PARMS) {
                 dot11info->new_device = true;
             }
 
-            if (dot11info->bssid_dev != nullptr)
+            if (dot11info->bssid_dev != nullptr && dot11info->subtype != packet_sub_probe_resp) {
                 dot11info->dest_dot11->set_last_bssid(dot11info->bssid_dev->get_macaddr());
+            }
 
             // If it's receiving a management packet, it must be a wifi device
             dot11info->dest_dev->set_type_string_ifnotany([d11phy]() {

--- a/phy_80211.cc
+++ b/phy_80211.cc
@@ -1500,9 +1500,9 @@ int kis_80211_phy::packet_dot11_common_classifier(CHAINCALL_PARMS) {
                 // If it's the source of a mgmt packet, it's got to be a wifi device of 
                 // some sort and not just bridged
                 dot11info->source_dev->set_type_string_ifnotany([d11phy]() { 
-                    return d11phy->devtype_client; 
+                    return d11phy->devtype_device;
                 }, (KIS_DEVICE_BASICTYPE_CLIENT | KIS_DEVICE_BASICTYPE_AP));
-                dot11info->source_dev->bitset_basic_type_set(KIS_DEVICE_BASICTYPE_CLIENT);
+                dot11info->source_dev->bitset_basic_type_set(KIS_DEVICE_BASICTYPE_DEVICE);
             }
 
             if (dot11info->subtype == packet_sub_probe_req ||
@@ -1535,12 +1535,22 @@ int kis_80211_phy::packet_dot11_common_classifier(CHAINCALL_PARMS) {
                 dot11info->dest_dot11->set_last_bssid(dot11info->bssid_dev->get_macaddr());
             }
 
-            // If it's receiving a management packet, it must be a wifi device
-            dot11info->dest_dev->set_type_string_ifnotany([d11phy]() {
-                return d11phy->devtype_client;
-            }, (KIS_DEVICE_BASICTYPE_CLIENT | KIS_DEVICE_BASICTYPE_AP));
-            dot11info->dest_dev->bitclear_basic_type_set(KIS_DEVICE_BASICTYPE_WIRED);
-            dot11info->dest_dev->bitset_basic_type_set(KIS_DEVICE_BASICTYPE_CLIENT);
+            // If it's receiving a management packet, it must be a wifi client
+            if (dot11info->subtype != packet_sub_probe_resp) {
+                dot11info->dest_dev->set_type_string_ifnotany([d11phy]() {
+                    return d11phy->devtype_client;
+                }, (KIS_DEVICE_BASICTYPE_CLIENT | KIS_DEVICE_BASICTYPE_AP));
+                dot11info->dest_dev->bitclear_basic_type_set(KIS_DEVICE_BASICTYPE_WIRED);
+                dot11info->dest_dev->bitclear_basic_type_set(KIS_DEVICE_BASICTYPE_DEVICE);
+                dot11info->dest_dev->bitset_basic_type_set(KIS_DEVICE_BASICTYPE_CLIENT);
+            } else {
+                // but only make it a wifi device if dest of a probe response
+                dot11info->dest_dev->set_type_string_ifnotany([d11phy]() {
+                    return d11phy->devtype_device;
+                }, (KIS_DEVICE_BASICTYPE_CLIENT | KIS_DEVICE_BASICTYPE_AP));
+                dot11info->dest_dev->bitclear_basic_type_set(KIS_DEVICE_BASICTYPE_WIRED);
+                dot11info->dest_dev->bitset_basic_type_set(KIS_DEVICE_BASICTYPE_DEVICE);
+            }
 
             d11phy->devicetracker->update_view_device(dot11info->dest_dev);
         }
@@ -1890,6 +1900,7 @@ int kis_80211_phy::packet_dot11_common_classifier(CHAINCALL_PARMS) {
                 dot11info->source_dev->set_type_string_ifnotany([d11phy]() {
                     return d11phy->devtype_client;
                 }, (KIS_DEVICE_BASICTYPE_CLIENT | KIS_DEVICE_BASICTYPE_AP));
+                dot11info->source_dev->bitclear_basic_type_set(KIS_DEVICE_BASICTYPE_DEVICE);
                 dot11info->source_dev->bitset_basic_type_set(KIS_DEVICE_BASICTYPE_CLIENT);
             } else if (dot11info->distrib == distrib_inter) {
                 // If it's from the ess, we're some sort of wired device; set the type
@@ -1912,8 +1923,8 @@ int kis_80211_phy::packet_dot11_common_classifier(CHAINCALL_PARMS) {
                 dot11info->source_dev->set_type_string_ifnotany([d11phy]() {
                     return d11phy->devtype_client;
                 }, (KIS_DEVICE_BASICTYPE_CLIENT | KIS_DEVICE_BASICTYPE_AP));
+                dot11info->source_dev->bitclear_basic_type_set(KIS_DEVICE_BASICTYPE_DEVICE);
                 dot11info->source_dev->bitset_basic_type_set(KIS_DEVICE_BASICTYPE_CLIENT);
-
             }
 
             dot11info->source_dot11->inc_datasize(dot11info->datasize);


### PR DESCRIPTION
1. First patch fixes the bug, where the last BSSID of wifi device is set the BSSID that respond with a probe reqeust.
   For example, a wifi device sends probe request, and some APs respond with a probe responses. You can watch this in real time in the device detail (as long as the device is not connected), the last BSSID changing as probe request come.
   This does not match the definition given of "Last BSSID" in the UI, which the last BSID connected to by the wifi client. Some device may only send probe request and not being a client, and not connected.

2. Second patch goes a little further and try to only classify a device as client if it send more than probe requests or receive probe responses