### PR TITLE
Fix listing of bluetooth capture linux device

### DIFF
--- a/capture_linux_bluetooth/capture_linux_bluetooth.c
+++ b/capture_linux_bluetooth/capture_linux_bluetooth.c
@@ -660,12 +660,13 @@ int list_callback(kis_capture_handler_t *caph, uint32_t seqno,
         return 0;
     }
 
-    /* Look at the files in the sys dir and see if they're wi-fi */
+    /* Look at the files in the sys dir and see if they're bluetooth */
     while ((devfile = readdir(devdir)) != NULL) {
-        /* AFAIK every hciX device in the /sys/class/bluetooth dir is a bluetooth
-         * controller */
-        unsigned int idx;
-        if (sscanf(devfile->d_name, "hci%u", &idx) == 1) {
+        /* Files in the /sys/class/bluetooth dir have names like hci<number>[:<number>]
+         * hci<number> are controllers while hci<number>:<number> are connected bt devices
+         */
+        unsigned int idx, idy;
+        if (sscanf(devfile->d_name, "hci%u:%u", &idx, &idy) == 1) {
             bt_list_t *d = (bt_list_t *) malloc(sizeof(bt_list_t));
             num_devs++;
             d->device = strdup(devfile->d_name);


### PR DESCRIPTION
Files in /sys/class/bluetooth have names like hci<number>[:<number>]

For example hci0:70 appears because of a bluetooth connected device but it is not a capture device

The bug is that all names are listed without filtering the ones with :<number> ending

The commit use a new format string but only use the filenames with one matching item i.e hci<number>