### PR TITLE
Make the nrf51822 work on OpenBSD

### DIFF
--- a/capture_nrf_51822/capture_nrf_51822.c
+++ b/capture_nrf_51822/capture_nrf_51822.c
@@ -15,7 +15,11 @@
 
 #define BUFFER_SIZE 256
 
+#if defined(SYS_OPENBSD)
+#define MODEMDEVICE "/dev/cuaU0"
+#else
 #define MODEMDEVICE "/dev/ttyUSB0"
+#endif
 
 #ifndef CRTSCTS
 #define CRTSCTS 020000000000 /*should be defined but isn't with the C99*/
@@ -310,8 +314,13 @@ int open_callback(kis_capture_handler_t *caph, uint32_t seqno, char *definition,
         sizeof(localnrf->newtio)); /* clear struct for new port settings */
 
     /* set the baud rate and flags */
+#if defined(SYS_OPENBSD)
+    localnrf->newtio.c_cflag = CRTSCTS | CS8 | CLOCAL | CREAD;
+    cfsetspeed(&localnrf->newtio, localnrf->baudrate);
+#else
     localnrf->newtio.c_cflag =
         localnrf->baudrate | CRTSCTS | CS8 | CLOCAL | CREAD;
+#endif
 
     /* ignore parity errors */
     localnrf->newtio.c_iflag = IGNPAR;


### PR DESCRIPTION
I'm maintainer of Kismet package on OpenBSD.
Current version is heavily outdated, so eventually decided to get the latest, and add OpenBSD support.
besides me getting Wi-Fi scanning to work, which needs some clean-up before I can open a MR, 
I also tinkered with a adafruit nrf51822 Sniffer.

Recognized, with lower baudrates, kismet started, and the capture_nrf_51822 was starting as well, but no BTLE packets were showing up in the interface. Trying to use higher baudrates, the tcsetattr() in capture_nrf_51822.c errored out with "failed to set serial device options".

the fix in the MR is inspired by looking at the OpenBSD cu utility, so instead of adding the baudrate to localnrf->newtio.c_cflag in one go together with the other flags, use cfsetspeed() to set the baudrate separately.

This makes it work like a charm.

The #ifdef around the MODEMDEVICE is only cosmetic, as it seems, MODEMDEVICE is not used anywhere, maybe it was intended for a future use?
