### PR TITLE
fix unknown type name FILE on musl

### DIFF
--- a/capture_linux_wifi/linux_wireless_control.c
+++ b/capture_linux_wifi/linux_wireless_control.c
@@ -31,6 +31,7 @@
 
 #include <sys/types.h>
 #include <dirent.h>
+#include <stdio.h>
 
 #ifdef HAVE_LINUX_WIRELESS
 #include <asm/types.h>


### PR DESCRIPTION
tested fix for:
```
gcc -Wall -Wno-unknown-warning-option -Wno-format-truncation -Wno-unused-function -g -I. -fPIE  -I/usr/include/libnl3   -pthread     -c linux_wireless_control.c -o linux_wireless_control.c.o
linux_wireless_control.c: In function 'linux_sys_get_regdom':
linux_wireless_control.c:707:5: error: unknown type name 'FILE'
  707 |     FILE *regf;
      |     ^~~~
linux_wireless_control.c:34:1: note: 'FILE' is defined in header '<stdio.h>'; did you forget to '#include <stdio.h>'?
   33 | #include <dirent.h>
  +++ |+#include <stdio.h>
   34 |
linux_wireless_control.c:709:17: warning: implicit declaration of function 'fopen' [-Wimplicit-function-declaration]
  709 |     if ((regf = fopen("/sys/module/cfg80211/parameters/ieee80211_regdom", "r")) == NULL)
      |                 ^~~~~
linux_wireless_control.c:709:17: note: 'fopen' is defined in header '<stdio.h>'; did you forget to '#include <stdio.h>'?
linux_wireless_control.c:709:15: warning: assignment to 'int *' from 'int' makes pointer from integer without a cast [-Wint-conversion]
  709 |     if ((regf = fopen("/sys/module/cfg80211/parameters/ieee80211_regdom", "r")) == NULL)
      |               ^
linux_wireless_control.c:712:9: warning: implicit declaration of function 'fscanf' [-Wimplicit-function-declaration]
  712 |     if (fscanf(regf, "%4s", ret_countrycode) != 1) {
      |         ^~~~~~
linux_wireless_control.c:712:9: note: include '<stdio.h>' or provide a declaration of 'fscanf'
linux_wireless_control.c:712:9: warning: incompatible implicit declaration of built-in function 'fscanf' [-Wbuiltin-declaration-mismatch]
linux_wireless_control.c:712:9: note: include '<stdio.h>' or provide a declaration of 'fscanf'
linux_wireless_control.c:713:9: warning: implicit declaration of function 'fclose' [-Wimplicit-function-declaration]
  713 |         fclose(regf);
      |         ^~~~~~
At top level:
cc1: note: unrecognized command-line option '-Wno-unknown-warning-option' may have been intended to silence earlier diagnostics
make[1]: *** [Makefile:31: linux_wireless_control.c.o] Error 1
make[1]: Leaving directory '/tmp/kismet/capture_linux_wifi'
make: *** [Makefile:335: capture_linux_wifi/kismet_cap_linux_wifi] Error 2
The command '/bin/sh -c make -j1' returned a non-zero code: 2
```