### PR TITLE
Allow building on OpenBSD

### DIFF
--- a/capture_pcapfile.c
+++ b/capture_pcapfile.c
@@ -290,10 +290,22 @@ void pcap_dispatch_cb(u_char *user, const struct pcap_pkthdr *header,
     /* Try repeatedly to send the packet; go into a thread wait state if
      * the write buffer is full & we'll be woken up as soon as it flushes
      * data out in the main select() loop */
+#if defined(__OpenBSD__)
+    /* OpenBSD has bpf_timeval in pcap_pkthdr */
+    struct timeval ts;
+#endif
     while (1) {
+#if defined(__OpenBSD__)
+        ts.tv_sec = header->ts.tv_sec;
+	ts.tv_usec = header->ts.tv_usec;
+#endif
         if ((ret = cf_send_data(caph, 
                         NULL, NULL, NULL,
-                        header->ts, 
+#if defined(__OpenBSD__)
+                        ts,
+#else
+                        header->ts,
+#endif
                         local_pcap->datalink_type,
                         header->caplen, (uint8_t *) data)) < 0) {
             pcap_breakloop(local_pcap->pd);

--- a/crc32.cc
+++ b/crc32.cc
@@ -18,6 +18,10 @@
 
 
 #include "crc32.h"
+#if defined(__OpenBSD__)
+#include "endian.h"
+#define __BYTE_ORDER BYTE_ORDER
+#endif
 
 #ifndef __LITTLE_ENDIAN
   #define __LITTLE_ENDIAN 1234

--- a/kaitaistream.cc
+++ b/kaitaistream.cc
@@ -19,7 +19,16 @@
 #define bswap_64(x) _byteswap_uint64(x)
 #else // !__APPLE__ or !_MSC_VER
 #include <endian.h>
+#if defined(__OpenBSD__)
+#define bswap_16(x) swap16(x)
+#define bswap_32(x) swap32(x)
+#define bswap_64(x) swap64(x)
+#define __BYTE_ORDER        BYTE_ORDER
+#define __BIG_ENDIAN    BIG_ENDIAN
+#define __LITTLE_ENDIAN LITTLE_ENDIAN
+#else // SYS_OPENBSD
 #include <byteswap.h>
+#endif
 #endif
 
 #include <iostream>

--- a/kis_dlt_radiotap.cc
+++ b/kis_dlt_radiotap.cc
@@ -31,6 +31,9 @@
 #include <net80211/ieee80211.h>
 #include <net80211/ieee80211_ioctl.h>
 #include <net80211/ieee80211_radiotap.h>
+#if defined(SYS_OPENBSD)
+#define ieee80211_radiotap_presence ieee80211_radiotap_type
+#endif
 #endif // Open/Net
 
 #ifdef SYS_FREEBSD
@@ -281,7 +284,7 @@ int kis_dlt_radiotap::handle_packet(std::shared_ptr<kis_packet> in_pack) {
                     u2.u8 = EXTRACT_LE_8BITS(iter);
                     iter += sizeof(u2.u8);
                     break;
-#endif
+#else
                 case IEEE80211_RADIOTAP_RX_FLAGS:
 					iter_align = ALIGN_OFFSET((unsigned int) (iter - iter_start), 2);
 					iter += iter_align;
@@ -304,7 +307,7 @@ int kis_dlt_radiotap::handle_packet(std::shared_ptr<kis_packet> in_pack) {
                 case IEEE80211_RADIOTAP_RADIOTAP_NAMESPACE:
                     /* Do nothing but acknowledge it */
                     break;
-
+#endif
                 case IEEE80211_RADIOTAP_EXT:
                     /* Do nothing but acknowledge it */
                     break;

--- a/kis_ppilogfile.h
+++ b/kis_ppilogfile.h
@@ -27,7 +27,11 @@
 #include <string>
 
 extern "C" {
+#if defined(__OpenBSD__)
+#include <pcap.h>
+#else
 #include <pcap/pcap.h>
+#endif
 }
 
 #include "globalregistry.h"


### PR DESCRIPTION
these changes are necessary to actually build Kismet on OpenBSD.

To prevent breakage for other platforms, everything guarded by #if defined (__OpenBSD__) or similar.
That makes it look a bit spaghetti, esp. in capture_pcapfile.c

Also with the change in kis_ppilogfile.h not sure if the ifdef dance is necessary, as there are many other files
including pcap.h directly as in OpenBSD.

Happy to adapt anything if necessary, let me know.