### PR TITLE
fix accidental reversal in udev rules

### DIFF
--- a/packaging/udev/99-kismet-nrf51822.rules
+++ b/packaging/udev/99-kismet-nrf51822.rules
@@ -1,2 +1,2 @@
-#this rule symlinks compatible devices flashed with nrf zigbee sniffer firmware to /dev/nrf51822# with # starting at 1
-ACTION=="add" SUBSYSTEM=="tty", ATTRS{idVendor}=="1915", ATTRS{idProduct}=="154a", PROGRAM="/bin/sh -c 'echo $(($(ls /dev/nrf51822* 2>/dev/null| tail -n1 | sed -e s#/dev/nrf51822## )+1))'", SYMLINK+="nrf51822%c"
+#this rule symlinks compatible devices flashed with nrf ble sniffer firmware to /dev/nrf51822# with # starting at 1
+ACTION=="add" SUBSYSTEM=="tty", ATTRS{idVendor}=="1915", ATTRS{idProduct}=="522a", PROGRAM="/bin/sh -c 'echo $(($(ls /dev/nrf51822* 2>/dev/null| tail -n1 | sed -e s#/dev/nrf51822## )+1))'", SYMLINK+="nrf51822%c"

--- a/packaging/udev/99-kismet-nrf52840.rules
+++ b/packaging/udev/99-kismet-nrf52840.rules
@@ -1,2 +1,2 @@
-#this rule symlinks compatible devices flashed with nrf ble sniffer firmware to /dev/nrf52840# with # starting at 1
-ACTION=="add" SUBSYSTEM=="tty", ATTRS{idVendor}=="1915", ATTRS{idProduct}=="522a", PROGRAM="/bin/sh -c 'echo $(($(ls /dev/nrf52840* 2>/dev/null| tail -n1 | sed -e s#/dev/nrf52840## )+1))'", SYMLINK+="nrf52840%c"
+#this rule symlinks compatible devices flashed with nrf zigbee sniffer firmware to /dev/nrf52840# with # starting at 1
+ACTION=="add" SUBSYSTEM=="tty", ATTRS{idVendor}=="1915", ATTRS{idProduct}=="154a", PROGRAM="/bin/sh -c 'echo $(($(ls /dev/nrf52840* 2>/dev/null| tail -n1 | sed -e s#/dev/nrf52840## )+1))'", SYMLINK+="nrf52840%c"


### PR DESCRIPTION
In retrospect it's obvious I copy pasta'd this since 154a should obviously be 802.15.4

Bus 001 Device 055: ID 1915:522a Nordic Semiconductor ASA nRF Sniffer for Bluetooth LE
Bus 001 Device 056: ID 1915:154a Nordic Semiconductor ASA nRF52 USB Product

This is tested and confirmed, my apologies for the mistake.