### PR TITLE
Fix path of homebrew's bin directory for Intel Macs

### DIFF
--- a/packaging/kismet_macos_configure_suid
+++ b/packaging/kismet_macos_configure_suid
@@ -19,7 +19,11 @@ if [ $(whoami) != "root" ]; then
     exit
 fi
 
-BIN=/opt/homebrew/bin/kismet_cap_osx_corewlan_wifi
+if [[ $(arch) == "arm64" || $(arch) == "arm64e" ]]; then
+    BIN=/opt/homebrew/bin/kismet_cap_osx_corewlan_wifi
+else
+    BIN=/usr/local/bin/kismet_cap_osx_corewlan_wifi
+fi
 
 TARGET=$(readlink -f ${BIN})
 USER=$(stat -f '%u' ${TARGET})


### PR DESCRIPTION
Hi, just noticed this minor issue when kismet was upgrading today - On Macs without Apple Silicon processors (i.e. Intel Macs), Homebrew defaults to use `/usr/local` as its base directory. Reference here: https://docs.brew.sh/Installation#:~:text=/opt/homebrew%20for%20Apple%20Silicon%2C%20/usr/local%20for%20macOS%20Intel