### PR TITLE
Implement `title` API param for logging endpoint

### DIFF
--- a/logtracker.cc
+++ b/logtracker.cc
@@ -19,7 +19,7 @@
 #include "config.h"
 
 #include <getopt.h>
-
+#include "json_adapter.h"
 #include "logtracker.h"
 #include "globalregistry.h"
 #include "messagebus.h"
@@ -229,6 +229,10 @@ void log_tracker::trigger_deferred_startup() {
 
                     if (builder == nullptr)
                         throw std::runtime_error("invalid logclass");
+                    
+                    if (!con->json()["title"].is_null()) {
+                        set_int_log_title(json_adapter::sanitize_string(con->json()["title"]));
+                    }
 
                     shared_logfile logf = open_log(builder);
 


### PR DESCRIPTION
Tested by a Discord user. 

Note expected behavior may need tweaking, from the user: 

For anyone else reading this in the future, Kismet starts with the logfile name defined in kismet_site.conf (if set).  If you stop logging with the API and then start again posting {"title": "CustomName"} your new log file will begin with CustomName.  If you stop logging with the API and start again (even without  posting{"title": "CustomName"} your new logfile will still start with CustomName (it does not automatically revert back to what you have in your config file).  If you want to go back to the logfile prefix defined in kismet_site.conf, restart Kismet or set it back with the API using title.