### PR TITLE
antsdr-droneid: add missing netdb.h header

### DIFF
--- a/capture_antsdr_droneid/capture_antsdr_droneid.c
+++ b/capture_antsdr_droneid/capture_antsdr_droneid.c
@@ -26,6 +26,7 @@
 
 #include <errno.h>
 #include <fcntl.h>
+#include <netdb.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>


### PR DESCRIPTION
Fixes #538:
implicit declaration of function ‘gethostbyname’