### PR TITLE
Fix typos + use https URLs

### DIFF
--- a/boost/beast/websocket/impl/close.hpp
+++ b/boost/beast/websocket/impl/close.hpp
@@ -256,7 +256,7 @@ public:
             if(ec == net::error::eof)
             {
                 // Rationale:
-                // http://stackoverflow.com/questions/25587403/boost-asio-ssl-async-shutdown-always-finishes-with-an-error
+                // https://stackoverflow.com/questions/25587403/boost-asio-ssl-async-shutdown-always-finishes-with-an-error
                 ec = {};
             }
             if(! ec)

--- a/boost/beast/websocket/impl/read.hpp
+++ b/boost/beast/websocket/impl/read.hpp
@@ -683,7 +683,7 @@ public:
             if(ec == net::error::eof)
             {
                 // Rationale:
-                // http://stackoverflow.com/questions/25587403/boost-asio-ssl-async-shutdown-always-finishes-with-an-error
+                // https://stackoverflow.com/questions/25587403/boost-asio-ssl-async-shutdown-always-finishes-with-an-error
                 ec = {};
             }
             if(! ec)

--- a/boost/beast/websocket/impl/ssl.hpp
+++ b/boost/beast/websocket/impl/ssl.hpp
@@ -21,7 +21,7 @@ namespace beast {
 /*
 
     See
-    http://stackoverflow.com/questions/32046034/what-is-the-proper-way-to-securely-disconnect-an-asio-ssl-socket/32054476#32054476
+    https://stackoverflow.com/questions/32046034/what-is-the-proper-way-to-securely-disconnect-an-asio-ssl-socket/32054476#32054476
 
     Behavior of ssl::stream regarding close_notify
 

--- a/boost/beast/websocket/impl/stream.hpp
+++ b/boost/beast/websocket/impl/stream.hpp
@@ -332,7 +332,7 @@ do_fail(
     if(ec == net::error::eof)
     {
         // Rationale:
-        // http://stackoverflow.com/questions/25587403/boost-asio-ssl-async-shutdown-always-finishes-with-an-error
+        // https://stackoverflow.com/questions/25587403/boost-asio-ssl-async-shutdown-always-finishes-with-an-error
         ec = {};
     }
     if(! ec)

--- a/capture_linux_bluetooth/README.md
+++ b/capture_linux_bluetooth/README.md
@@ -1,4 +1,3 @@
 # Kismet Linux Bluetooth
 
 Uses the bluez management socket API to initiate scans for devices
-

--- a/configure
+++ b/configure
@@ -5354,7 +5354,7 @@ namespace cxx11
 
   }
 
-  // http://stackoverflow.com/questions/13728184/template-aliases-and-sfinae
+  // https://stackoverflow.com/questions/13728184/template-aliases-and-sfinae
   // Clang 3.1 fails with headers of libstd++ 4.8.3 when using std::function
   // because of this.
   namespace test_template_alias_sfinae
@@ -6199,7 +6199,7 @@ namespace cxx11
 
   }
 
-  // http://stackoverflow.com/questions/13728184/template-aliases-and-sfinae
+  // https://stackoverflow.com/questions/13728184/template-aliases-and-sfinae
   // Clang 3.1 fails with headers of libstd++ 4.8.3 when using std::function
   // because of this.
   namespace test_template_alias_sfinae
@@ -7058,7 +7058,7 @@ namespace cxx11
 
   }
 
-  // http://stackoverflow.com/questions/13728184/template-aliases-and-sfinae
+  // https://stackoverflow.com/questions/13728184/template-aliases-and-sfinae
   // Clang 3.1 fails with headers of libstd++ 4.8.3 when using std::function
   // because of this.
   namespace test_template_alias_sfinae
@@ -7954,7 +7954,7 @@ namespace cxx11
 
   }
 
-  // http://stackoverflow.com/questions/13728184/template-aliases-and-sfinae
+  // https://stackoverflow.com/questions/13728184/template-aliases-and-sfinae
   // Clang 3.1 fails with headers of libstd++ 4.8.3 when using std::function
   // because of this.
   namespace test_template_alias_sfinae
@@ -8773,7 +8773,7 @@ namespace cxx11
 
   }
 
-  // http://stackoverflow.com/questions/13728184/template-aliases-and-sfinae
+  // https://stackoverflow.com/questions/13728184/template-aliases-and-sfinae
   // Clang 3.1 fails with headers of libstd++ 4.8.3 when using std::function
   // because of this.
   namespace test_template_alias_sfinae
@@ -9606,7 +9606,7 @@ namespace cxx11
 
   }
 
-  // http://stackoverflow.com/questions/13728184/template-aliases-and-sfinae
+  // https://stackoverflow.com/questions/13728184/template-aliases-and-sfinae
   // Clang 3.1 fails with headers of libstd++ 4.8.3 when using std::function
   // because of this.
   namespace test_template_alias_sfinae

--- a/http_data/js/kismet.utils.js
+++ b/http_data/js/kismet.utils.js
@@ -31,7 +31,7 @@ exports.putStorage = function(key, data) {
     exports.storage.set(key, data);
 }
 
-// From http://stackoverflow.com/a/6491621
+// From https://stackoverflow.com/a/6491621
 exports.ObjectByString = function(o, s) {
     if (typeof(o) === 'undefined')
         return;

--- a/http_data/js/spectrum.js
+++ b/http_data/js/spectrum.js
@@ -2181,7 +2181,7 @@
     }
 
     // Need to handle 1.0 as 100%, since once it is a number, there is no difference between it and 1
-    // <http://stackoverflow.com/questions/7422072/javascript-how-to-detect-number-as-a-decimal-including-1-0>
+    // <https://stackoverflow.com/questions/7422072/javascript-how-to-detect-number-as-a-decimal-including-1-0>
     function isOnePointZero(n) {
         return typeof n == "string" && n.indexOf('.') != -1 && parseFloat(n) === 1;
     }

--- a/m4/ax_cxx_compile_stdcxx.m4
+++ b/m4/ax_cxx_compile_stdcxx.m4
@@ -452,7 +452,7 @@ namespace cxx11
 
   }
 
-  // http://stackoverflow.com/questions/13728184/template-aliases-and-sfinae
+  // https://stackoverflow.com/questions/13728184/template-aliases-and-sfinae
   // Clang 3.1 fails with headers of libstd++ 4.8.3 when using std::function
   // because of this.
   namespace test_template_alias_sfinae

--- a/moodycamel/concurrentqueue.h
+++ b/moodycamel/concurrentqueue.h
@@ -108,7 +108,7 @@ namespace moodycamel { namespace details {
 #elif defined(__arm__) || defined(_M_ARM) || defined(__aarch64__) || (defined(__APPLE__) && TARGET_OS_IPHONE) || defined(MOODYCAMEL_NO_THREAD_LOCAL)
 namespace moodycamel { namespace details {
 	static_assert(sizeof(std::thread::id) == 4 || sizeof(std::thread::id) == 8, "std::thread::id is expected to be either 4 or 8 bytes");
-	
+
 	typedef std::thread::id thread_id_t;
 	static const thread_id_t invalid_thread_id;         // Default ctor creates invalid ID
 
@@ -140,7 +140,7 @@ namespace moodycamel { namespace details {
 	};
 } }
 #else
-// Use a nice trick from this answer: http://stackoverflow.com/a/8438730/21475
+// Use a nice trick from this answer: https://stackoverflow.com/a/8438730/21475
 // In order to get a numeric thread ID in a platform-independent way, we use a thread-local
 // static variable's address as a thread identifier :-)
 #if defined(__GNUC__) || defined(__INTEL_COMPILER)
@@ -322,7 +322,7 @@ struct ConcurrentQueueDefaultTraits
 {
 	// General-purpose size type. std::size_t is strongly recommended.
 	typedef std::size_t size_t;
-	
+
 	// The type used for the enqueue and dequeue indices. Must be at least as
 	// large as size_t. Should be significantly larger than the number of elements
 	// you expect to hold at once, especially if you have a high turnover rate;
@@ -334,40 +334,40 @@ struct ConcurrentQueueDefaultTraits
 	// whether the queue is lock-free with a 64-int type depends on the whether
 	// std::atomic<std::uint64_t> is lock-free, which is platform-specific.
 	typedef std::size_t index_t;
-	
+
 	// Internally, all elements are enqueued and dequeued from multi-element
 	// blocks; this is the smallest controllable unit. If you expect few elements
 	// but many producers, a smaller block size should be favoured. For few producers
 	// and/or many elements, a larger block size is preferred. A sane default
 	// is provided. Must be a power of 2.
 	static const size_t BLOCK_SIZE = 32;
-	
+
 	// For explicit producers (i.e. when using a producer token), the block is
 	// checked for being empty by iterating through a list of flags, one per element.
 	// For large block sizes, this is too inefficient, and switching to an atomic
 	// counter-based approach is faster. The switch is made for block sizes strictly
 	// larger than this threshold.
 	static const size_t EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD = 32;
-	
+
 	// How many full blocks can be expected for a single explicit producer? This should
 	// reflect that number's maximum for optimal performance. Must be a power of 2.
 	static const size_t EXPLICIT_INITIAL_INDEX_SIZE = 32;
-	
+
 	// How many full blocks can be expected for a single implicit producer? This should
 	// reflect that number's maximum for optimal performance. Must be a power of 2.
 	static const size_t IMPLICIT_INITIAL_INDEX_SIZE = 32;
-	
+
 	// The initial size of the hash table mapping thread IDs to implicit producers.
 	// Note that the hash is resized every time it becomes half full.
 	// Must be a power of two, and either 0 or at least 1. If 0, implicit production
 	// (using the enqueue methods without an explicit producer token) is disabled.
 	static const size_t INITIAL_IMPLICIT_PRODUCER_HASH_SIZE = 32;
-	
+
 	// Controls the number of items that an explicit consumer (i.e. one with a token)
 	// must consume before it causes all consumers to rotate and move on to the next
 	// internal queue.
 	static const std::uint32_t EXPLICIT_CONSUMER_CONSUMPTION_QUOTA_BEFORE_ROTATE = 256;
-	
+
 	// The maximum number of elements (inclusive) that can be enqueued to a sub-queue.
 	// Enqueue operations that would cause this limit to be surpassed will fail. Note
 	// that this limit is enforced at the block level (for performance reasons), i.e.
@@ -387,7 +387,7 @@ struct ConcurrentQueueDefaultTraits
 	// of the queue (not following destruction of the token) regardless of this trait.
 	static const bool RECYCLE_ALLOCATED_BLOCKS = false;
 
-	
+
 #ifndef MCDBGQ_USE_RELACY
 	// Memory allocation can be customized if needed.
 	// malloc should return nullptr on failure, and handle alignment like std::malloc.
@@ -433,13 +433,13 @@ namespace details
 		ConcurrentQueueProducerTypelessBase* next;
 		std::atomic<bool> inactive;
 		ProducerToken* token;
-		
+
 		ConcurrentQueueProducerTypelessBase()
 			: next(nullptr), inactive(false), token(nullptr)
 		{
 		}
 	};
-	
+
 	template<bool use32> struct _hash_32_or_64 {
 		static inline std::uint32_t hash(std::uint32_t h)
 		{
@@ -465,14 +465,14 @@ namespace details
 		}
 	};
 	template<std::size_t size> struct hash_32_or_64 : public _hash_32_or_64<(size > 4)> {  };
-	
+
 	static inline size_t hash_thread_id(thread_id_t id)
 	{
 		static_assert(sizeof(thread_id_t) <= 8, "Expected a platform where thread IDs are at most 64-bit values");
 		return static_cast<size_t>(hash_32_or_64<sizeof(thread_id_converter<thread_id_t>::thread_id_hash_t)>::hash(
 			thread_id_converter<thread_id_t>::prehash(id)));
 	}
-	
+
 	template<typename T>
 	static inline bool circular_less_than(T a, T b)
 	{
@@ -481,7 +481,7 @@ namespace details
 		// Note: extra parens around rhs of operator<< is MSVC bug: https://developercommunity2.visualstudio.com/t/C4554-triggers-when-both-lhs-and-rhs-is/10034931
 		//       silencing the bug requires #pragma warning(disable: 4554) around the calling code and has no effect when done here.
 	}
-	
+
 	template<typename U>
 	static inline char* align_for(char* ptr)
 	{
@@ -505,7 +505,7 @@ namespace details
 		++x;
 		return x;
 	}
-	
+
 	template<typename T>
 	static inline void swap_relaxed(std::atomic<T>& left, std::atomic<T>& right)
 	{
@@ -513,13 +513,13 @@ namespace details
 		left.store(std::move(right.load(std::memory_order_relaxed)), std::memory_order_relaxed);
 		right.store(std::move(temp), std::memory_order_relaxed);
 	}
-	
+
 	template<typename T>
 	static inline T const& nomove(T const& x)
 	{
 		return x;
 	}
-	
+
 	template<bool Enable>
 	struct nomove_if
 	{
@@ -529,7 +529,7 @@ namespace details
 			return x;
 		}
 	};
-	
+
 	template<>
 	struct nomove_if<false>
 	{
@@ -540,19 +540,19 @@ namespace details
 			return std::forward<U>(x);
 		}
 	};
-	
+
 	template<typename It>
 	static inline auto deref_noexcept(It& it) MOODYCAMEL_NOEXCEPT -> decltype(*it)
 	{
 		return *it;
 	}
-	
+
 #if defined(__clang__) || !defined(__GNUC__) || __GNUC__ > 4 || (__GNUC__ == 4 && __GNUC_MINOR__ >= 8)
 	template<typename T> struct is_trivially_destructible : std::is_trivially_destructible<T> { };
 #else
 	template<typename T> struct is_trivially_destructible : std::has_trivial_destructor<T> { };
 #endif
-	
+
 #ifdef MOODYCAMEL_CPP11_THREAD_LOCAL_SUPPORTED
 #ifdef MCDBGQ_USE_RELACY
 	typedef RelacyThreadExitListener ThreadExitListener;
@@ -565,7 +565,7 @@ namespace details
 		typedef void (*callback_t)(void*);
 		callback_t callback;
 		void* userData;
-		
+
 		ThreadExitListener* next;		// reserved for use by the ThreadExitNotifier
 		ThreadExitNotifier* chain;		// reserved for use by the ThreadExitNotifier
 	};
@@ -581,7 +581,7 @@ namespace details
 			listener->chain = &tlsInst;
 			tlsInst.tail = listener;
 		}
-		
+
 		static void unsubscribe(ThreadExitListener* listener)
 		{
 			std::lock_guard<std::mutex> guard(mutex());
@@ -599,12 +599,12 @@ namespace details
 				prev = &ptr->next;
 			}
 		}
-		
+
 	private:
 		ThreadExitNotifier() : tail(nullptr) { }
 		ThreadExitNotifier(ThreadExitNotifier const&) MOODYCAMEL_DELETE_FUNCTION;
 		ThreadExitNotifier& operator=(ThreadExitNotifier const&) MOODYCAMEL_DELETE_FUNCTION;
-		
+
 		~ThreadExitNotifier()
 		{
 			// This thread is about to exit, let everyone know!
@@ -615,7 +615,7 @@ namespace details
 				ptr->callback(ptr->userData);
 			}
 		}
-		
+
 		// Thread-local
 		static inline ThreadExitNotifier& instance()
 		{
@@ -629,13 +629,13 @@ namespace details
 			static std::mutex mutex;
 			return mutex;
 		}
-		
+
 	private:
 		ThreadExitListener* tail;
 	};
 #endif
 #endif
-	
+
 	template<typename T> struct static_is_lock_free_num { enum { value = 0 }; };
 	template<> struct static_is_lock_free_num<signed char> { enum { value = ATOMIC_CHAR_LOCK_FREE }; };
 	template<> struct static_is_lock_free_num<short> { enum { value = ATOMIC_SHORT_LOCK_FREE }; };
@@ -652,10 +652,10 @@ struct ProducerToken
 {
 	template<typename T, typename Traits>
 	explicit ProducerToken(ConcurrentQueue<T, Traits>& queue);
-	
+
 	template<typename T, typename Traits>
 	explicit ProducerToken(BlockingConcurrentQueue<T, Traits>& queue);
-	
+
 	ProducerToken(ProducerToken&& other) MOODYCAMEL_NOEXCEPT
 		: producer(other.producer)
 	{
@@ -664,13 +664,13 @@ struct ProducerToken
 			producer->token = this;
 		}
 	}
-	
+
 	inline ProducerToken& operator=(ProducerToken&& other) MOODYCAMEL_NOEXCEPT
 	{
 		swap(other);
 		return *this;
 	}
-	
+
 	void swap(ProducerToken& other) MOODYCAMEL_NOEXCEPT
 	{
 		std::swap(producer, other.producer);
@@ -681,7 +681,7 @@ struct ProducerToken
 			other.producer->token = &other;
 		}
 	}
-	
+
 	// A token is always valid unless:
 	//     1) Memory allocation failed during construction
 	//     2) It was moved via the move constructor
@@ -691,7 +691,7 @@ struct ProducerToken
 	// that the token is valid for use with a specific queue,
 	// but not which one; that's up to the user to track.
 	inline bool valid() const { return producer != nullptr; }
-	
+
 	~ProducerToken()
 	{
 		if (producer != nullptr) {
@@ -699,15 +699,15 @@ struct ProducerToken
 			producer->inactive.store(true, std::memory_order_release);
 		}
 	}
-	
+
 	// Disable copying and assignment
 	ProducerToken(ProducerToken const&) MOODYCAMEL_DELETE_FUNCTION;
 	ProducerToken& operator=(ProducerToken const&) MOODYCAMEL_DELETE_FUNCTION;
-	
+
 private:
 	template<typename T, typename Traits> friend class ConcurrentQueue;
 	friend class ConcurrentQueueTests;
-	
+
 protected:
 	details::ConcurrentQueueProducerTypelessBase* producer;
 };
@@ -717,21 +717,21 @@ struct ConsumerToken
 {
 	template<typename T, typename Traits>
 	explicit ConsumerToken(ConcurrentQueue<T, Traits>& q);
-	
+
 	template<typename T, typename Traits>
 	explicit ConsumerToken(BlockingConcurrentQueue<T, Traits>& q);
-	
+
 	ConsumerToken(ConsumerToken&& other) MOODYCAMEL_NOEXCEPT
 		: initialOffset(other.initialOffset), lastKnownGlobalOffset(other.lastKnownGlobalOffset), itemsConsumedFromCurrent(other.itemsConsumedFromCurrent), currentProducer(other.currentProducer), desiredProducer(other.desiredProducer)
 	{
 	}
-	
+
 	inline ConsumerToken& operator=(ConsumerToken&& other) MOODYCAMEL_NOEXCEPT
 	{
 		swap(other);
 		return *this;
 	}
-	
+
 	void swap(ConsumerToken& other) MOODYCAMEL_NOEXCEPT
 	{
 		std::swap(initialOffset, other.initialOffset);
@@ -740,7 +740,7 @@ struct ConsumerToken
 		std::swap(currentProducer, other.currentProducer);
 		std::swap(desiredProducer, other.desiredProducer);
 	}
-	
+
 	// Disable copying and assignment
 	ConsumerToken(ConsumerToken const&) MOODYCAMEL_DELETE_FUNCTION;
 	ConsumerToken& operator=(ConsumerToken const&) MOODYCAMEL_DELETE_FUNCTION;
@@ -748,7 +748,7 @@ struct ConsumerToken
 private:
 	template<typename T, typename Traits> friend class ConcurrentQueue;
 	friend class ConcurrentQueueTests;
-	
+
 private: // but shared with ConcurrentQueue
 	std::uint32_t initialOffset;
 	std::uint32_t lastKnownGlobalOffset;
@@ -758,7 +758,7 @@ private: // but shared with ConcurrentQueue
 };
 
 // Need to forward-declare this swap because it's in a namespace.
-// See http://stackoverflow.com/questions/4492062/why-does-a-c-friend-class-need-a-forward-declaration-only-in-other-namespaces
+// See https://stackoverflow.com/questions/4492062/why-does-a-c-friend-class-need-a-forward-declaration-only-in-other-namespaces
 template<typename T, typename Traits>
 inline void swap(typename ConcurrentQueue<T, Traits>::ImplicitProducerKVP& a, typename ConcurrentQueue<T, Traits>::ImplicitProducerKVP& b) MOODYCAMEL_NOEXCEPT;
 
@@ -769,10 +769,10 @@ class ConcurrentQueue
 public:
 	typedef ::moodycamel::ProducerToken producer_token_t;
 	typedef ::moodycamel::ConsumerToken consumer_token_t;
-	
+
 	typedef typename Traits::index_t index_t;
 	typedef typename Traits::size_t size_t;
-	
+
 	static const size_t BLOCK_SIZE = static_cast<size_t>(Traits::BLOCK_SIZE);
 	static const size_t EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD = static_cast<size_t>(Traits::EXPLICIT_BLOCK_EMPTY_COUNTER_THRESHOLD);
 	static const size_t EXPLICIT_INITIAL_INDEX_SIZE = static_cast<size_t>(Traits::EXPLICIT_INITIAL_INDEX_SIZE);
@@ -820,7 +820,7 @@ public:
 		implicitProducerHashResizeInProgress.clear(std::memory_order_relaxed);
 		populate_initial_implicit_producer_hash();
 		populate_initial_block_list(capacity / BLOCK_SIZE + ((capacity & (BLOCK_SIZE - 1)) == 0 ? 0 : 1));
-		
+
 #ifdef MOODYCAMEL_QUEUE_INTERNAL_DEBUG
 		// Track all the producers using a fully-resolved typed list for
 		// each kind; this makes it possible to debug them starting from
@@ -830,7 +830,7 @@ public:
 		implicitProducers.store(nullptr, std::memory_order_relaxed);
 #endif
 	}
-	
+
 	// Computes the correct amount of pre-allocated blocks for you based
 	// on the minimum number of elements you want available at any given
 	// time, and the maximum concurrent number of each type of producer.
@@ -845,13 +845,13 @@ public:
 		populate_initial_implicit_producer_hash();
 		size_t blocks = (((minCapacity + BLOCK_SIZE - 1) / BLOCK_SIZE) - 1) * (maxExplicitProducers + 1) + 2 * (maxExplicitProducers + maxImplicitProducers);
 		populate_initial_block_list(blocks);
-		
+
 #ifdef MOODYCAMEL_QUEUE_INTERNAL_DEBUG
 		explicitProducers.store(nullptr, std::memory_order_relaxed);
 		implicitProducers.store(nullptr, std::memory_order_relaxed);
 #endif
 	}
-	
+
 	// Note: The queue should not be accessed concurrently while it's
 	// being deleted. It's up to the user to synchronize this.
 	// This method is not thread safe.
@@ -867,7 +867,7 @@ public:
 			destroy(ptr);
 			ptr = next;
 		}
-		
+
 		// Destroy implicit producer hash tables
 		MOODYCAMEL_CONSTEXPR_IF (INITIAL_IMPLICIT_PRODUCER_HASH_SIZE != 0) {
 			auto hash = implicitProducerHash.load(std::memory_order_relaxed);
@@ -883,7 +883,7 @@ public:
 				hash = prev;
 			}
 		}
-		
+
 		// Destroy global free list
 		auto block = freeList.head_unsafe();
 		while (block != nullptr) {
@@ -893,7 +893,7 @@ public:
 			}
 			block = next;
 		}
-		
+
 		// Destroy initial free list
 		destroy_array(initialBlockPool, initialBlockPoolSize);
 	}
@@ -901,7 +901,7 @@ public:
 	// Disable copying and copy assignment
 	ConcurrentQueue(ConcurrentQueue const&) MOODYCAMEL_DELETE_FUNCTION;
 	ConcurrentQueue& operator=(ConcurrentQueue const&) MOODYCAMEL_DELETE_FUNCTION;
-	
+
 	// Moving is supported, but note that it is *not* a thread-safe operation.
 	// Nobody can use the queue while it's being moved, and the memory effects
 	// of that move must be propagated to other threads before they can use it.
@@ -922,31 +922,31 @@ public:
 		implicitProducerHashResizeInProgress.clear(std::memory_order_relaxed);
 		populate_initial_implicit_producer_hash();
 		swap_implicit_producer_hashes(other);
-		
+
 		other.producerListTail.store(nullptr, std::memory_order_relaxed);
 		other.producerCount.store(0, std::memory_order_relaxed);
 		other.nextExplicitConsumerId.store(0, std::memory_order_relaxed);
 		other.globalExplicitConsumerOffset.store(0, std::memory_order_relaxed);
-		
+
 #ifdef MOODYCAMEL_QUEUE_INTERNAL_DEBUG
 		explicitProducers.store(other.explicitProducers.load(std::memory_order_relaxed), std::memory_order_relaxed);
 		other.explicitProducers.store(nullptr, std::memory_order_relaxed);
 		implicitProducers.store(other.implicitProducers.load(std::memory_order_relaxed), std::memory_order_relaxed);
 		other.implicitProducers.store(nullptr, std::memory_order_relaxed);
 #endif
-		
+
 		other.initialBlockPoolIndex.store(0, std::memory_order_relaxed);
 		other.initialBlockPoolSize = 0;
 		other.initialBlockPool = nullptr;
-		
+
 		reown_producers();
 	}
-	
+
 	inline ConcurrentQueue& operator=(ConcurrentQueue&& other) MOODYCAMEL_NOEXCEPT
 	{
 		return swap_internal(other);
 	}
-	
+
 	// Swaps this queue's state with the other's. Not thread-safe.
 	// Swapping two queues does not invalidate their tokens, however
 	// the tokens that were created for one queue must be used with
@@ -956,14 +956,14 @@ public:
 	{
 		swap_internal(other);
 	}
-	
+
 private:
 	ConcurrentQueue& swap_internal(ConcurrentQueue& other)
 	{
 		if (this == &other) {
 			return *this;
 		}
-		
+
 		details::swap_relaxed(producerListTail, other.producerListTail);
 		details::swap_relaxed(producerCount, other.producerCount);
 		details::swap_relaxed(initialBlockPoolIndex, other.initialBlockPoolIndex);
@@ -972,20 +972,20 @@ private:
 		freeList.swap(other.freeList);
 		details::swap_relaxed(nextExplicitConsumerId, other.nextExplicitConsumerId);
 		details::swap_relaxed(globalExplicitConsumerOffset, other.globalExplicitConsumerOffset);
-		
+
 		swap_implicit_producer_hashes(other);
-		
+
 		reown_producers();
 		other.reown_producers();
-		
+
 #ifdef MOODYCAMEL_QUEUE_INTERNAL_DEBUG
 		details::swap_relaxed(explicitProducers, other.explicitProducers);
 		details::swap_relaxed(implicitProducers, other.implicitProducers);
 #endif
-		
+
 		return *this;
 	}
-	
+
 public:
 	// Enqueues a single item (by copying it).
 	// Allocates memory if required. Only fails if memory allocation fails (or implicit
@@ -997,7 +997,7 @@ public:
 		MOODYCAMEL_CONSTEXPR_IF (INITIAL_IMPLICIT_PRODUCER_HASH_SIZE == 0) return false;
 		else return inner_enqueue<CanAlloc>(item);
 	}
-	
+
 	// Enqueues a single item (by moving it, if possible).
 	// Allocates memory if required. Only fails if memory allocation fails (or implicit
 	// production is disabled because Traits::INITIAL_IMPLICIT_PRODUCER_HASH_SIZE is 0,
@@ -1008,7 +1008,7 @@ public:
 		MOODYCAMEL_CONSTEXPR_IF (INITIAL_IMPLICIT_PRODUCER_HASH_SIZE == 0) return false;
 		else return inner_enqueue<CanAlloc>(std::move(item));
 	}
-	
+
 	// Enqueues a single item (by copying it) using an explicit producer token.
 	// Allocates memory if required. Only fails if memory allocation fails (or
 	// Traits::MAX_SUBQUEUE_SIZE has been defined and would be surpassed).
@@ -1017,7 +1017,7 @@ public:
 	{
 		return inner_enqueue<CanAlloc>(token, item);
 	}
-	
+
 	// Enqueues a single item (by moving it, if possible) using an explicit producer token.
 	// Allocates memory if required. Only fails if memory allocation fails (or
 	// Traits::MAX_SUBQUEUE_SIZE has been defined and would be surpassed).
@@ -1026,7 +1026,7 @@ public:
 	{
 		return inner_enqueue<CanAlloc>(token, std::move(item));
 	}
-	
+
 	// Enqueues several items.
 	// Allocates memory if required. Only fails if memory allocation fails (or
 	// implicit production is disabled because Traits::INITIAL_IMPLICIT_PRODUCER_HASH_SIZE
@@ -1039,7 +1039,7 @@ public:
 		MOODYCAMEL_CONSTEXPR_IF (INITIAL_IMPLICIT_PRODUCER_HASH_SIZE == 0) return false;
 		else return inner_enqueue_bulk<CanAlloc>(itemFirst, count);
 	}
-	
+
 	// Enqueues several items using an explicit producer token.
 	// Allocates memory if required. Only fails if memory allocation fails
 	// (or Traits::MAX_SUBQUEUE_SIZE has been defined and would be surpassed).
@@ -1051,7 +1051,7 @@ public:
 	{
 		return inner_enqueue_bulk<CanAlloc>(token, itemFirst, count);
 	}
-	
+
 	// Enqueues a single item (by copying it).
 	// Does not allocate memory. Fails if not enough room to enqueue (or implicit
 	// production is disabled because Traits::INITIAL_IMPLICIT_PRODUCER_HASH_SIZE
@@ -1062,7 +1062,7 @@ public:
 		MOODYCAMEL_CONSTEXPR_IF (INITIAL_IMPLICIT_PRODUCER_HASH_SIZE == 0) return false;
 		else return inner_enqueue<CannotAlloc>(item);
 	}
-	
+
 	// Enqueues a single item (by moving it, if possible).
 	// Does not allocate memory (except for one-time implicit producer).
 	// Fails if not enough room to enqueue (or implicit production is
@@ -1073,7 +1073,7 @@ public:
 		MOODYCAMEL_CONSTEXPR_IF (INITIAL_IMPLICIT_PRODUCER_HASH_SIZE == 0) return false;
 		else return inner_enqueue<CannotAlloc>(std::move(item));
 	}
-	
+
 	// Enqueues a single item (by copying it) using an explicit producer token.
 	// Does not allocate memory. Fails if not enough room to enqueue.
 	// Thread-safe.
@@ -1081,7 +1081,7 @@ public:
 	{
 		return inner_enqueue<CannotAlloc>(token, item);
 	}
-	
+
 	// Enqueues a single item (by moving it, if possible) using an explicit producer token.
 	// Does not allocate memory. Fails if not enough room to enqueue.
 	// Thread-safe.
@@ -1089,7 +1089,7 @@ public:
 	{
 		return inner_enqueue<CannotAlloc>(token, std::move(item));
 	}
-	
+
 	// Enqueues several items.
 	// Does not allocate memory (except for one-time implicit producer).
 	// Fails if not enough room to enqueue (or implicit production is
@@ -1103,7 +1103,7 @@ public:
 		MOODYCAMEL_CONSTEXPR_IF (INITIAL_IMPLICIT_PRODUCER_HASH_SIZE == 0) return false;
 		else return inner_enqueue_bulk<CannotAlloc>(itemFirst, count);
 	}
-	
+
 	// Enqueues several items using an explicit producer token.
 	// Does not allocate memory. Fails if not enough room to enqueue.
 	// Note: Use std::make_move_iterator if the elements should be moved
@@ -1114,9 +1114,9 @@ public:
 	{
 		return inner_enqueue_bulk<CannotAlloc>(token, itemFirst, count);
 	}
-	
-	
-	
+
+
+
 	// Attempts to dequeue from the queue.
 	// Returns false if all producer streams appeared empty at the time they
 	// were checked (so, the queue is likely but not guaranteed to be empty).
@@ -1139,7 +1139,7 @@ public:
 				++nonEmptyCount;
 			}
 		}
-		
+
 		// If there was at least one non-empty queue but it appears empty at the time
 		// we try to dequeue from it, we need to make sure every queue's been tried
 		if (nonEmptyCount > 0) {
@@ -1154,7 +1154,7 @@ public:
 		}
 		return false;
 	}
-	
+
 	// Attempts to dequeue from the queue.
 	// Returns false if all producer streams appeared empty at the time they
 	// were checked (so, the queue is likely but not guaranteed to be empty).
@@ -1174,7 +1174,7 @@ public:
 		}
 		return false;
 	}
-	
+
 	// Attempts to dequeue from the queue using an explicit consumer token.
 	// Returns false if all producer streams appeared empty at the time they
 	// were checked (so, the queue is likely but not guaranteed to be empty).
@@ -1187,13 +1187,13 @@ public:
 		// If you see that the global offset has changed, you must reset your consumption counter and move to your designated place
 		// If there's no items where you're supposed to be, keep moving until you find a producer with some items
 		// If the global offset has not changed but you've run out of items to consume, move over from your current position until you find an producer with something in it
-		
+
 		if (token.desiredProducer == nullptr || token.lastKnownGlobalOffset != globalExplicitConsumerOffset.load(std::memory_order_relaxed)) {
 			if (!update_current_producer_after_rotation(token)) {
 				return false;
 			}
 		}
-		
+
 		// If there was at least one non-empty queue but it appears empty at the time
 		// we try to dequeue from it, we need to make sure every queue's been tried
 		if (static_cast<ProducerBase*>(token.currentProducer)->dequeue(item)) {
@@ -1202,7 +1202,7 @@ public:
 			}
 			return true;
 		}
-		
+
 		auto tail = producerListTail.load(std::memory_order_acquire);
 		auto ptr = static_cast<ProducerBase*>(token.currentProducer)->next_prod();
 		if (ptr == nullptr) {
@@ -1221,7 +1221,7 @@ public:
 		}
 		return false;
 	}
-	
+
 	// Attempts to dequeue several elements from the queue.
 	// Returns the number of items actually dequeued.
 	// Returns 0 if all producer streams appeared empty at the time they
@@ -1239,7 +1239,7 @@ public:
 		}
 		return count;
 	}
-	
+
 	// Attempts to dequeue several elements from the queue using an explicit consumer token.
 	// Returns the number of items actually dequeued.
 	// Returns 0 if all producer streams appeared empty at the time they
@@ -1253,7 +1253,7 @@ public:
 				return 0;
 			}
 		}
-		
+
 		size_t count = static_cast<ProducerBase*>(token.currentProducer)->dequeue_bulk(itemFirst, max);
 		if (count == max) {
 			if ((token.itemsConsumedFromCurrent += static_cast<std::uint32_t>(max)) >= EXPLICIT_CONSUMER_CONSUMPTION_QUOTA_BEFORE_ROTATE) {
@@ -1263,7 +1263,7 @@ public:
 		}
 		token.itemsConsumedFromCurrent += static_cast<std::uint32_t>(count);
 		max -= count;
-		
+
 		auto tail = producerListTail.load(std::memory_order_acquire);
 		auto ptr = static_cast<ProducerBase*>(token.currentProducer)->next_prod();
 		if (ptr == nullptr) {
@@ -1287,9 +1287,9 @@ public:
 		}
 		return count;
 	}
-	
-	
-	
+
+
+
 	// Attempts to dequeue from a specific producer's inner queue.
 	// If you happen to know which producer you want to dequeue from, this
 	// is significantly faster than using the general-case try_dequeue methods.
@@ -1301,7 +1301,7 @@ public:
 	{
 		return static_cast<ExplicitProducer*>(producer.producer)->dequeue(item);
 	}
-	
+
 	// Attempts to dequeue several elements from a specific producer's inner queue.
 	// Returns the number of items actually dequeued.
 	// If you happen to know which producer you want to dequeue from, this
@@ -1314,8 +1314,8 @@ public:
 	{
 		return static_cast<ExplicitProducer*>(producer.producer)->dequeue_bulk(itemFirst, max);
 	}
-	
-	
+
+
 	// Returns an estimate of the total number of elements currently in the queue. This
 	// estimate is only accurate if the queue has completely stabilized before it is called
 	// (i.e. all enqueue and dequeue operations have completed and their memory effects are
@@ -1330,8 +1330,8 @@ public:
 		}
 		return size;
 	}
-	
-	
+
+
 	// Returns true if the underlying atomic variables used by
 	// the queue are lock-free (they should be on most platforms).
 	// Thread-safe.
@@ -1355,40 +1355,40 @@ private:
 	struct ImplicitProducer;
 	friend struct ImplicitProducer;
 	friend class ConcurrentQueueTests;
-		
+
 	enum AllocationMode { CanAlloc, CannotAlloc };
-	
-	
+
+
 	///////////////////////////////
 	// Queue methods
 	///////////////////////////////
-	
+
 	template<AllocationMode canAlloc, typename U>
 	inline bool inner_enqueue(producer_token_t const& token, U&& element)
 	{
 		return static_cast<ExplicitProducer*>(token.producer)->ConcurrentQueue::ExplicitProducer::template enqueue<canAlloc>(std::forward<U>(element));
 	}
-	
+
 	template<AllocationMode canAlloc, typename U>
 	inline bool inner_enqueue(U&& element)
 	{
 		auto producer = get_or_add_implicit_producer();
 		return producer == nullptr ? false : producer->ConcurrentQueue::ImplicitProducer::template enqueue<canAlloc>(std::forward<U>(element));
 	}
-	
+
 	template<AllocationMode canAlloc, typename It>
 	inline bool inner_enqueue_bulk(producer_token_t const& token, It itemFirst, size_t count)
 	{
 		return static_cast<ExplicitProducer*>(token.producer)->ConcurrentQueue::ExplicitProducer::template enqueue_bulk<canAlloc>(itemFirst, count);
 	}
-	
+
 	template<AllocationMode canAlloc, typename It>
 	inline bool inner_enqueue_bulk(It itemFirst, size_t count)
 	{
 		auto producer = get_or_add_implicit_producer();
 		return producer == nullptr ? false : producer->ConcurrentQueue::ImplicitProducer::template enqueue_bulk<canAlloc>(itemFirst, count);
 	}
-	
+
 	inline bool update_current_producer_after_rotation(consumer_token_t& token)
 	{
 		// Ah, there's been a rotation, figure out where we should be!
@@ -1411,7 +1411,7 @@ private:
 				}
 			}
 		}
-		
+
 		std::uint32_t delta = globalOffset - token.lastKnownGlobalOffset;
 		if (delta >= prodCount) {
 			delta = delta % prodCount;
@@ -1422,27 +1422,27 @@ private:
 				token.desiredProducer = tail;
 			}
 		}
-		
+
 		token.lastKnownGlobalOffset = globalOffset;
 		token.currentProducer = token.desiredProducer;
 		token.itemsConsumedFromCurrent = 0;
 		return true;
 	}
-	
-	
+
+
 	///////////////////////////
 	// Free list
 	///////////////////////////
-	
+
 	template <typename N>
 	struct FreeListNode
 	{
 		FreeListNode() : freeListRefs(0), freeListNext(nullptr) { }
-		
+
 		std::atomic<std::uint32_t> freeListRefs;
 		std::atomic<N*> freeListNext;
 	};
-	
+
 	// A simple CAS-based lock-free free list. Not the fastest thing in the world under heavy contention, but
 	// simple and correct (assuming nodes are never freed until after the free list is destroyed), and fairly
 	// speedy under low contention.
@@ -1452,15 +1452,15 @@ private:
 		FreeList() : freeListHead(nullptr) { }
 		FreeList(FreeList&& other) : freeListHead(other.freeListHead.load(std::memory_order_relaxed)) { other.freeListHead.store(nullptr, std::memory_order_relaxed); }
 		void swap(FreeList& other) { details::swap_relaxed(freeListHead, other.freeListHead); }
-		
+
 		FreeList(FreeList const&) MOODYCAMEL_DELETE_FUNCTION;
 		FreeList& operator=(FreeList const&) MOODYCAMEL_DELETE_FUNCTION;
-		
+
 		inline void add(N* node)
 		{
 #ifdef MCDBGQ_NOLOCKFREE_FREELIST
 			debug::DebugLock lock(mutex);
-#endif		
+#endif
 			// We know that the should-be-on-freelist bit is 0 at this point, so it's safe to
 			// set it using a fetch_add
 			if (node->freeListRefs.fetch_add(SHOULD_BE_ON_FREELIST, std::memory_order_acq_rel) == 0) {
@@ -1469,12 +1469,12 @@ private:
 		 		add_knowing_refcount_is_zero(node);
 			}
 		}
-		
+
 		inline N* try_get()
 		{
 #ifdef MCDBGQ_NOLOCKFREE_FREELIST
 			debug::DebugLock lock(mutex);
-#endif		
+#endif
 			auto head = freeListHead.load(std::memory_order_acquire);
 			while (head != nullptr) {
 				auto prevHead = head;
@@ -1483,7 +1483,7 @@ private:
 					head = freeListHead.load(std::memory_order_acquire);
 					continue;
 				}
-				
+
 				// Good, reference count has been incremented (it wasn't at zero), which means we can read the
 				// next and not worry about it changing between now and the time we do the CAS
 				auto next = head->freeListNext.load(std::memory_order_relaxed);
@@ -1491,12 +1491,12 @@ private:
 					// Yay, got the node. This means it was on the list, which means shouldBeOnFreeList must be false no
 					// matter the refcount (because nobody else knows it's been taken off yet, it can't have been put back on).
 					assert((head->freeListRefs.load(std::memory_order_relaxed) & SHOULD_BE_ON_FREELIST) == 0);
-					
+
 					// Decrease refcount twice, once for our ref, and once for the list's ref
 					head->freeListRefs.fetch_sub(2, std::memory_order_release);
 					return head;
 				}
-				
+
 				// OK, the head must have changed on us, but we still need to decrease the refcount we increased.
 				// Note that we don't need to release any memory effects, but we do need to ensure that the reference
 				// count decrement happens-after the CAS on the head.
@@ -1505,13 +1505,13 @@ private:
 					add_knowing_refcount_is_zero(prevHead);
 				}
 			}
-			
+
 			return nullptr;
 		}
-		
+
 		// Useful for traversing the list when there's no contention (e.g. to destroy remaining nodes)
 		N* head_unsafe() const { return freeListHead.load(std::memory_order_relaxed); }
-		
+
 	private:
 		inline void add_knowing_refcount_is_zero(N* node)
 		{
@@ -1536,26 +1536,26 @@ private:
 				return;
 			}
 		}
-		
+
 	private:
 		// Implemented like a stack, but where node order doesn't matter (nodes are inserted out of order under contention)
 		std::atomic<N*> freeListHead;
-	
+
 	static const std::uint32_t REFS_MASK = 0x7FFFFFFF;
 	static const std::uint32_t SHOULD_BE_ON_FREELIST = 0x80000000;
-		
+
 #ifdef MCDBGQ_NOLOCKFREE_FREELIST
 		debug::DebugMutex mutex;
 #endif
 	};
-	
-	
+
+
 	///////////////////////////
 	// Block
 	///////////////////////////
-	
+
 	enum InnerQueueContext { implicit_context = 0, explicit_context = 1 };
-	
+
 	struct Block
 	{
 		Block()
@@ -1565,7 +1565,7 @@ private:
 			owner = nullptr;
 #endif
 		}
-		
+
 		template<InnerQueueContext context>
 		inline bool is_empty() const
 		{
@@ -1576,7 +1576,7 @@ private:
 						return false;
 					}
 				}
-				
+
 				// Aha, empty; make sure we have all other memory effects that happened before the empty flags were set
 				std::atomic_thread_fence(std::memory_order_acquire);
 				return true;
@@ -1591,7 +1591,7 @@ private:
 				return false;
 			}
 		}
-		
+
 		// Returns true if the block is now empty (does not apply in explicit context)
 		template<InnerQueueContext context>
 		inline bool set_empty(MOODYCAMEL_MAYBE_UNUSED index_t i)
@@ -1609,7 +1609,7 @@ private:
 				return prevVal == BLOCK_SIZE - 1;
 			}
 		}
-		
+
 		// Sets multiple contiguous item statuses to 'empty' (assumes no wrapping and count > 0).
 		// Returns true if the block is now empty (does not apply in explicit context).
 		template<InnerQueueContext context>
@@ -1632,7 +1632,7 @@ private:
 				return prevVal + count == BLOCK_SIZE;
 			}
 		}
-		
+
 		template<InnerQueueContext context>
 		inline void set_all_empty()
 		{
@@ -1647,7 +1647,7 @@ private:
 				elementsCompletelyDequeued.store(BLOCK_SIZE, std::memory_order_relaxed);
 			}
 		}
-		
+
 		template<InnerQueueContext context>
 		inline void reset_empty()
 		{
@@ -1662,10 +1662,10 @@ private:
 				elementsCompletelyDequeued.store(0, std::memory_order_relaxed);
 			}
 		}
-		
+
 		inline T* operator[](index_t idx) MOODYCAMEL_NOEXCEPT { return static_cast<T*>(static_cast<void*>(elements)) + static_cast<size_t>(idx & static_cast<index_t>(BLOCK_SIZE - 1)); }
 		inline T const* operator[](index_t idx) const MOODYCAMEL_NOEXCEPT { return static_cast<T const*>(static_cast<void const*>(elements)) + static_cast<size_t>(idx & static_cast<index_t>(BLOCK_SIZE - 1)); }
-		
+
 	private:
 		static_assert(std::alignment_of<T>::value <= sizeof(T), "The queue does not support types with an alignment greater than their size at this time");
 		MOODYCAMEL_ALIGNED_TYPE_LIKE(char[sizeof(T) * BLOCK_SIZE], T) elements;
@@ -1677,7 +1677,7 @@ private:
 		std::atomic<std::uint32_t> freeListRefs;
 		std::atomic<Block*> freeListNext;
 		bool dynamicallyAllocated;		// Perhaps a better name for this would be 'isNotPartOfInitialBlockPool'
-		
+
 #ifdef MCDBGQ_TRACKMEM
 		void* owner;
 #endif
@@ -1690,11 +1690,11 @@ public:
 	struct MemStats;
 private:
 #endif
-	
+
 	///////////////////////////
 	// Producer base
 	///////////////////////////
-	
+
 	struct ProducerBase : public details::ConcurrentQueueProducerTypelessBase
 	{
 		ProducerBase(ConcurrentQueue* parent_, bool isExplicit_) :
@@ -1707,9 +1707,9 @@ private:
 			parent(parent_)
 		{
 		}
-		
+
 		virtual ~ProducerBase() { }
-		
+
 		template<typename U>
 		inline bool dequeue(U& element)
 		{
@@ -1720,7 +1720,7 @@ private:
 				return static_cast<ImplicitProducer*>(this)->dequeue(element);
 			}
 		}
-		
+
 		template<typename It>
 		inline size_t dequeue_bulk(It& itemFirst, size_t max)
 		{
@@ -1731,41 +1731,41 @@ private:
 				return static_cast<ImplicitProducer*>(this)->dequeue_bulk(itemFirst, max);
 			}
 		}
-		
+
 		inline ProducerBase* next_prod() const { return static_cast<ProducerBase*>(next); }
-		
+
 		inline size_t size_approx() const
 		{
 			auto tail = tailIndex.load(std::memory_order_relaxed);
 			auto head = headIndex.load(std::memory_order_relaxed);
 			return details::circular_less_than(head, tail) ? static_cast<size_t>(tail - head) : 0;
 		}
-		
+
 		inline index_t getTail() const { return tailIndex.load(std::memory_order_relaxed); }
 	protected:
 		std::atomic<index_t> tailIndex;		// Where to enqueue to next
 		std::atomic<index_t> headIndex;		// Where to dequeue from next
-		
+
 		std::atomic<index_t> dequeueOptimisticCount;
 		std::atomic<index_t> dequeueOvercommit;
-		
+
 		Block* tailBlock;
-		
+
 	public:
 		bool isExplicit;
 		ConcurrentQueue* parent;
-		
+
 	protected:
 #ifdef MCDBGQ_TRACKMEM
 		friend struct MemStats;
 #endif
 	};
-	
-	
+
+
 	///////////////////////////
 	// Explicit queue
 	///////////////////////////
-		
+
 	struct ExplicitProducer : public ProducerBase
 	{
 		explicit ExplicitProducer(ConcurrentQueue* parent_) :
@@ -1781,10 +1781,10 @@ private:
 			if (poolBasedIndexSize > pr_blockIndexSize) {
 				pr_blockIndexSize = poolBasedIndexSize;
 			}
-			
+
 			new_block_index(0);		// This creates an index with double the number of current entries, i.e. EXPLICIT_INITIAL_INDEX_SIZE
 		}
-		
+
 		~ExplicitProducer()
 		{
 			// Destruct any elements not yet dequeued.
@@ -1803,7 +1803,7 @@ private:
 					assert(details::circular_less_than<index_t>(pr_blockIndexEntries[i].base, this->headIndex.load(std::memory_order_relaxed)));
 					halfDequeuedBlock = pr_blockIndexEntries[i].block;
 				}
-				
+
 				// Start at the head block (note the first line in the loop gives us the head from the tail on the first iteration)
 				auto block = this->tailBlock;
 				do {
@@ -1811,12 +1811,12 @@ private:
 					if (block->ConcurrentQueue::Block::template is_empty<explicit_context>()) {
 						continue;
 					}
-					
+
 					size_t i = 0;	// Offset into block
 					if (block == halfDequeuedBlock) {
 						i = static_cast<size_t>(this->headIndex.load(std::memory_order_relaxed) & static_cast<index_t>(BLOCK_SIZE - 1));
 					}
-					
+
 					// Walk through all the items in the block; if this is the tail block, we need to stop when we reach the tail index
 					auto lastValidIndex = (this->tailIndex.load(std::memory_order_relaxed) & static_cast<index_t>(BLOCK_SIZE - 1)) == 0 ? BLOCK_SIZE : static_cast<size_t>(this->tailIndex.load(std::memory_order_relaxed) & static_cast<index_t>(BLOCK_SIZE - 1));
 					while (i != BLOCK_SIZE && (block != this->tailBlock || i != lastValidIndex)) {
@@ -1824,7 +1824,7 @@ private:
 					}
 				} while (block != this->tailBlock);
 			}
-			
+
 			// Destroy all blocks that we own
 			if (this->tailBlock != nullptr) {
 				auto block = this->tailBlock;
@@ -1834,7 +1834,7 @@ private:
 					block = nextBlock;
 				} while (block != this->tailBlock);
 			}
-			
+
 			// Destroy the block indices
 			auto header = static_cast<BlockIndexHeader*>(pr_blockIndexRaw);
 			while (header != nullptr) {
@@ -1844,7 +1844,7 @@ private:
 				header = prev;
 			}
 		}
-		
+
 		template<AllocationMode allocMode, typename U>
 		inline bool enqueue(U&& element)
 		{
@@ -1855,10 +1855,10 @@ private:
 				auto startBlock = this->tailBlock;
 				auto originalBlockIndexSlotsUsed = pr_blockIndexSlotsUsed;
 				if (this->tailBlock != nullptr && this->tailBlock->next->ConcurrentQueue::Block::template is_empty<explicit_context>()) {
-					// We can re-use the block ahead of us, it's empty!					
+					// We can re-use the block ahead of us, it's empty!
 					this->tailBlock = this->tailBlock->next;
 					this->tailBlock->ConcurrentQueue::Block::template reset_empty<explicit_context>();
-					
+
 					// We'll put the block on the block index (guaranteed to be room since we're conceptually removing the
 					// last block from it first -- except instead of removing then adding, we can just overwrite).
 					// Note that there must be a valid block index here, since even if allocation failed in the ctor,
@@ -1883,7 +1883,7 @@ private:
 						// Hmm, the circular block index is already full -- we'll need
 						// to allocate a new index. Note pr_blockIndexRaw can only be nullptr if
 						// the initial allocation failed in the constructor.
-						
+
 						MOODYCAMEL_CONSTEXPR_IF (allocMode == CannotAlloc) {
 							return false;
 						}
@@ -1891,7 +1891,7 @@ private:
 							return false;
 						}
 					}
-					
+
 					// Insert a new block in the circular linked list
 					auto newBlock = this->parent->ConcurrentQueue::template requisition_block<allocMode>();
 					if (newBlock == nullptr) {
@@ -1930,27 +1930,27 @@ private:
 					(void)startBlock;
 					(void)originalBlockIndexSlotsUsed;
 				}
-				
+
 				// Add block to block index
 				auto& entry = blockIndex.load(std::memory_order_relaxed)->entries[pr_blockIndexFront];
 				entry.base = currentTailIndex;
 				entry.block = this->tailBlock;
 				blockIndex.load(std::memory_order_relaxed)->front.store(pr_blockIndexFront, std::memory_order_release);
 				pr_blockIndexFront = (pr_blockIndexFront + 1) & (pr_blockIndexSize - 1);
-				
+
 				MOODYCAMEL_CONSTEXPR_IF (!MOODYCAMEL_NOEXCEPT_CTOR(T, U, new (static_cast<T*>(nullptr)) T(std::forward<U>(element)))) {
 					this->tailIndex.store(newTailIndex, std::memory_order_release);
 					return true;
 				}
 			}
-			
+
 			// Enqueue
 			new ((*this->tailBlock)[currentTailIndex]) T(std::forward<U>(element));
-			
+
 			this->tailIndex.store(newTailIndex, std::memory_order_release);
 			return true;
 		}
-		
+
 		template<typename U>
 		bool dequeue(U& element)
 		{
@@ -1958,10 +1958,10 @@ private:
 			auto overcommit = this->dequeueOvercommit.load(std::memory_order_relaxed);
 			if (details::circular_less_than<index_t>(this->dequeueOptimisticCount.load(std::memory_order_relaxed) - overcommit, tail)) {
 				// Might be something to dequeue, let's give it a try
-				
+
 				// Note that this if is purely for performance purposes in the common case when the queue is
 				// empty and the values are eventually consistent -- we may enter here spuriously.
-				
+
 				// Note that whatever the values of overcommit and tail are, they are not going to change (unless we
 				// change them) and must be the same value at this point (inside the if) as when the if condition was
 				// evaluated.
@@ -1972,26 +1972,26 @@ private:
 				// Note that I believe a compiler (signal) fence here would be sufficient due to the nature of fetch_add (all
 				// read-modify-write operations are guaranteed to work on the latest value in the modification order), but
 				// unfortunately that can't be shown to be correct using only the C++11 standard.
-				// See http://stackoverflow.com/questions/18223161/what-are-the-c11-memory-ordering-guarantees-in-this-corner-case
+				// See https://stackoverflow.com/questions/18223161/what-are-the-c11-memory-ordering-guarantees-in-this-corner-case
 				std::atomic_thread_fence(std::memory_order_acquire);
-				
+
 				// Increment optimistic counter, then check if it went over the boundary
 				auto myDequeueCount = this->dequeueOptimisticCount.fetch_add(1, std::memory_order_relaxed);
-				
+
 				// Note that since dequeueOvercommit must be <= dequeueOptimisticCount (because dequeueOvercommit is only ever
 				// incremented after dequeueOptimisticCount -- this is enforced in the `else` block below), and since we now
 				// have a version of dequeueOptimisticCount that is at least as recent as overcommit (due to the release upon
 				// incrementing dequeueOvercommit and the acquire above that synchronizes with it), overcommit <= myDequeueCount.
 				// However, we can't assert this since both dequeueOptimisticCount and dequeueOvercommit may (independently)
 				// overflow; in such a case, though, the logic still holds since the difference between the two is maintained.
-				
+
 				// Note that we reload tail here in case it changed; it will be the same value as before or greater, since
 				// this load is sequenced after (happens after) the earlier load above. This is supported by read-read
 				// coherency (as defined in the standard), explained here: http://en.cppreference.com/w/cpp/atomic/memory_order
 				tail = this->tailIndex.load(std::memory_order_acquire);
 				if ((details::likely)(details::circular_less_than<index_t>(myDequeueCount - overcommit, tail))) {
 					// Guaranteed to be at least one element to dequeue!
-					
+
 					// Get the index. Note that since there's guaranteed to be at least one element, this
 					// will never exceed tail. We need to do an acquire-release fence here since it's possible
 					// that whatever condition got us to this point was for an earlier enqueued element (that
@@ -2001,13 +2001,13 @@ private:
 					// place with the more current condition (they must have acquired a tail that is at least
 					// as recent).
 					auto index = this->headIndex.fetch_add(1, std::memory_order_acq_rel);
-					
-					
+
+
 					// Determine which block the element is in
-					
+
 					auto localBlockIndex = blockIndex.load(std::memory_order_acquire);
 					auto localBlockIndexHead = localBlockIndex->front.load(std::memory_order_acquire);
-					
+
 					// We need to be careful here about subtracting and dividing because of index wrap-around.
 					// When an index wraps, we need to preserve the sign of the offset when dividing it by the
 					// block size (in order to get a correct signed block count offset in all cases):
@@ -2015,7 +2015,7 @@ private:
 					auto blockBaseIndex = index & ~static_cast<index_t>(BLOCK_SIZE - 1);
 					auto offset = static_cast<size_t>(static_cast<typename std::make_signed<index_t>::type>(blockBaseIndex - headBase) / static_cast<typename std::make_signed<index_t>::type>(BLOCK_SIZE));
 					auto block = localBlockIndex->entries[(localBlockIndexHead + offset) & (localBlockIndex->size - 1)].block;
-					
+
 					// Dequeue
 					auto& el = *((*block)[index]);
 					if (!MOODYCAMEL_NOEXCEPT_ASSIGN(T, T&&, element = std::move(el))) {
@@ -2024,7 +2024,7 @@ private:
 						struct Guard {
 							Block* block;
 							index_t index;
-							
+
 							~Guard()
 							{
 								(*block)[index]->~T();
@@ -2039,7 +2039,7 @@ private:
 						el.~T(); // NOLINT
 						block->ConcurrentQueue::Block::template set_empty<explicit_context>(index);
 					}
-					
+
 					return true;
 				}
 				else {
@@ -2047,10 +2047,10 @@ private:
 					this->dequeueOvercommit.fetch_add(1, std::memory_order_release);		// Release so that the fetch_add on dequeueOptimisticCount is guaranteed to happen before this write
 				}
 			}
-		
+
 			return false;
 		}
-		
+
 		template<AllocationMode allocMode, typename It>
 		bool MOODYCAMEL_NO_TSAN enqueue_bulk(It itemFirst, size_t count)
 		{
@@ -2061,9 +2061,9 @@ private:
 			auto startBlock = this->tailBlock;
 			auto originalBlockIndexFront = pr_blockIndexFront;
 			auto originalBlockIndexSlotsUsed = pr_blockIndexSlotsUsed;
-			
+
 			Block* firstAllocatedBlock = nullptr;
-			
+
 			// Figure out how many blocks we'll need to allocate, and do so
 			size_t blockBaseDiff = ((startTailIndex + count - 1) & ~static_cast<index_t>(BLOCK_SIZE - 1)) - ((startTailIndex - 1) & ~static_cast<index_t>(BLOCK_SIZE - 1));
 			index_t currentTailIndex = (startTailIndex - 1) & ~static_cast<index_t>(BLOCK_SIZE - 1);
@@ -2072,21 +2072,21 @@ private:
 				while (blockBaseDiff > 0 && this->tailBlock != nullptr && this->tailBlock->next != firstAllocatedBlock && this->tailBlock->next->ConcurrentQueue::Block::template is_empty<explicit_context>()) {
 					blockBaseDiff -= static_cast<index_t>(BLOCK_SIZE);
 					currentTailIndex += static_cast<index_t>(BLOCK_SIZE);
-					
+
 					this->tailBlock = this->tailBlock->next;
 					firstAllocatedBlock = firstAllocatedBlock == nullptr ? this->tailBlock : firstAllocatedBlock;
-					
+
 					auto& entry = blockIndex.load(std::memory_order_relaxed)->entries[pr_blockIndexFront];
 					entry.base = currentTailIndex;
 					entry.block = this->tailBlock;
 					pr_blockIndexFront = (pr_blockIndexFront + 1) & (pr_blockIndexSize - 1);
 				}
-				
+
 				// Now allocate as many blocks as necessary from the block pool
 				while (blockBaseDiff > 0) {
 					blockBaseDiff -= static_cast<index_t>(BLOCK_SIZE);
 					currentTailIndex += static_cast<index_t>(BLOCK_SIZE);
-					
+
 					auto head = this->headIndex.load(std::memory_order_relaxed);
 					assert(!details::circular_less_than<index_t>(currentTailIndex, head));
 					bool full = !details::circular_less_than<index_t>(head, currentTailIndex + BLOCK_SIZE) || (MAX_SUBQUEUE_SIZE != details::const_numeric_max<size_t>::value && (MAX_SUBQUEUE_SIZE == 0 || MAX_SUBQUEUE_SIZE - BLOCK_SIZE < currentTailIndex - head));
@@ -2105,13 +2105,13 @@ private:
 							this->tailBlock = startBlock == nullptr ? firstAllocatedBlock : startBlock;
 							return false;
 						}
-						
+
 						// pr_blockIndexFront is updated inside new_block_index, so we need to
 						// update our fallback value too (since we keep the new index even if we
 						// later fail)
 						originalBlockIndexFront = originalBlockIndexSlotsUsed;
 					}
-					
+
 					// Insert a new block in the circular linked list
 					auto newBlock = this->parent->ConcurrentQueue::template requisition_block<allocMode>();
 					if (newBlock == nullptr) {
@@ -2120,7 +2120,7 @@ private:
 						this->tailBlock = startBlock == nullptr ? firstAllocatedBlock : startBlock;
 						return false;
 					}
-					
+
 #ifdef MCDBGQ_TRACKMEM
 					newBlock->owner = this;
 #endif
@@ -2134,15 +2134,15 @@ private:
 					}
 					this->tailBlock = newBlock;
 					firstAllocatedBlock = firstAllocatedBlock == nullptr ? this->tailBlock : firstAllocatedBlock;
-					
+
 					++pr_blockIndexSlotsUsed;
-					
+
 					auto& entry = blockIndex.load(std::memory_order_relaxed)->entries[pr_blockIndexFront];
 					entry.base = currentTailIndex;
 					entry.block = this->tailBlock;
 					pr_blockIndexFront = (pr_blockIndexFront + 1) & (pr_blockIndexSize - 1);
 				}
-				
+
 				// Excellent, all allocations succeeded. Reset each block's emptiness before we fill them up, and
 				// publish the new block index front
 				auto block = firstAllocatedBlock;
@@ -2153,12 +2153,12 @@ private:
 					}
 					block = block->next;
 				}
-				
+
 				MOODYCAMEL_CONSTEXPR_IF (MOODYCAMEL_NOEXCEPT_CTOR(T, decltype(*itemFirst), new (static_cast<T*>(nullptr)) T(details::deref_noexcept(itemFirst)))) {
 					blockIndex.load(std::memory_order_relaxed)->front.store((pr_blockIndexFront - 1) & (pr_blockIndexSize - 1), std::memory_order_release);
 				}
 			}
-			
+
 			// Enqueue, one block at a time
 			index_t newTailIndex = startTailIndex + static_cast<index_t>(count);
 			currentTailIndex = startTailIndex;
@@ -2199,11 +2199,11 @@ private:
 						// any allocated blocks in our linked list for later, though).
 						auto constructedStopIndex = currentTailIndex;
 						auto lastBlockEnqueued = this->tailBlock;
-						
+
 						pr_blockIndexFront = originalBlockIndexFront;
 						pr_blockIndexSlotsUsed = originalBlockIndexSlotsUsed;
 						this->tailBlock = startBlock == nullptr ? firstAllocatedBlock : startBlock;
-						
+
 						if (!details::is_trivially_destructible<T>::value) {
 							auto block = startBlock;
 							if ((startTailIndex & static_cast<index_t>(BLOCK_SIZE - 1)) == 0) {
@@ -2227,23 +2227,23 @@ private:
 						MOODYCAMEL_RETHROW;
 					}
 				}
-				
+
 				if (this->tailBlock == endBlock) {
 					assert(currentTailIndex == newTailIndex);
 					break;
 				}
 				this->tailBlock = this->tailBlock->next;
 			}
-			
+
 			MOODYCAMEL_CONSTEXPR_IF (!MOODYCAMEL_NOEXCEPT_CTOR(T, decltype(*itemFirst), new (static_cast<T*>(nullptr)) T(details::deref_noexcept(itemFirst)))) {
 				if (firstAllocatedBlock != nullptr)
 					blockIndex.load(std::memory_order_relaxed)->front.store((pr_blockIndexFront - 1) & (pr_blockIndexSize - 1), std::memory_order_release);
 			}
-			
+
 			this->tailIndex.store(newTailIndex, std::memory_order_release);
 			return true;
 		}
-		
+
 		template<typename It>
 		size_t dequeue_bulk(It& itemFirst, size_t max)
 		{
@@ -2253,9 +2253,9 @@ private:
 			if (details::circular_less_than<size_t>(0, desiredCount)) {
 				desiredCount = desiredCount < max ? desiredCount : max;
 				std::atomic_thread_fence(std::memory_order_acquire);
-				
+
 				auto myDequeueCount = this->dequeueOptimisticCount.fetch_add(desiredCount, std::memory_order_relaxed);
-				
+
 				tail = this->tailIndex.load(std::memory_order_acquire);
 				auto actualCount = static_cast<size_t>(tail - (myDequeueCount - overcommit));
 				if (details::circular_less_than<size_t>(0, actualCount)) {
@@ -2263,20 +2263,20 @@ private:
 					if (actualCount < desiredCount) {
 						this->dequeueOvercommit.fetch_add(desiredCount - actualCount, std::memory_order_release);
 					}
-					
+
 					// Get the first index. Note that since there's guaranteed to be at least actualCount elements, this
 					// will never exceed tail.
 					auto firstIndex = this->headIndex.fetch_add(actualCount, std::memory_order_acq_rel);
-					
+
 					// Determine which block the first element is in
 					auto localBlockIndex = blockIndex.load(std::memory_order_acquire);
 					auto localBlockIndexHead = localBlockIndex->front.load(std::memory_order_acquire);
-					
+
 					auto headBase = localBlockIndex->entries[localBlockIndexHead].base;
 					auto firstBlockBaseIndex = firstIndex & ~static_cast<index_t>(BLOCK_SIZE - 1);
 					auto offset = static_cast<size_t>(static_cast<typename std::make_signed<index_t>::type>(firstBlockBaseIndex - headBase) / static_cast<typename std::make_signed<index_t>::type>(BLOCK_SIZE));
 					auto indexIndex = (localBlockIndexHead + offset) & (localBlockIndex->size - 1);
-					
+
 					// Iterate the blocks and dequeue
 					auto index = firstIndex;
 					do {
@@ -2313,19 +2313,19 @@ private:
 									}
 									block->ConcurrentQueue::Block::template set_many_empty<explicit_context>(firstIndexInBlock, static_cast<size_t>(endIndex - firstIndexInBlock));
 									indexIndex = (indexIndex + 1) & (localBlockIndex->size - 1);
-									
+
 									firstIndexInBlock = index;
 									endIndex = (index & ~static_cast<index_t>(BLOCK_SIZE - 1)) + static_cast<index_t>(BLOCK_SIZE);
 									endIndex = details::circular_less_than<index_t>(firstIndex + static_cast<index_t>(actualCount), endIndex) ? firstIndex + static_cast<index_t>(actualCount) : endIndex;
 								} while (index != firstIndex + actualCount);
-								
+
 								MOODYCAMEL_RETHROW;
 							}
 						}
 						block->ConcurrentQueue::Block::template set_many_empty<explicit_context>(firstIndexInBlock, static_cast<size_t>(endIndex - firstIndexInBlock));
 						indexIndex = (indexIndex + 1) & (localBlockIndex->size - 1);
 					} while (index != firstIndex + actualCount);
-					
+
 					return actualCount;
 				}
 				else {
@@ -2333,17 +2333,17 @@ private:
 					this->dequeueOvercommit.fetch_add(desiredCount, std::memory_order_release);
 				}
 			}
-			
+
 			return 0;
 		}
-		
+
 	private:
 		struct BlockIndexEntry
 		{
 			index_t base;
 			Block* block;
 		};
-		
+
 		struct BlockIndexHeader
 		{
 			size_t size;
@@ -2351,12 +2351,12 @@ private:
 			BlockIndexEntry* entries;
 			void* prev;
 		};
-		
-		
+
+
 		bool new_block_index(size_t numberOfFilledSlotsToExpose)
 		{
 			auto prevBlockSizeMask = pr_blockIndexSize - 1;
-			
+
 			// Create the new block
 			pr_blockIndexSize <<= 1;
 			auto newRawPtr = static_cast<char*>((Traits::malloc)(sizeof(BlockIndexHeader) + std::alignment_of<BlockIndexEntry>::value - 1 + sizeof(BlockIndexEntry) * pr_blockIndexSize));
@@ -2364,9 +2364,9 @@ private:
 				pr_blockIndexSize >>= 1;		// Reset to allow graceful retry
 				return false;
 			}
-			
+
 			auto newBlockIndexEntries = reinterpret_cast<BlockIndexEntry*>(details::align_for<BlockIndexEntry>(newRawPtr + sizeof(BlockIndexHeader)));
-			
+
 			// Copy in all the old indices, if any
 			size_t j = 0;
 			if (pr_blockIndexSlotsUsed != 0) {
@@ -2376,50 +2376,50 @@ private:
 					i = (i + 1) & prevBlockSizeMask;
 				} while (i != pr_blockIndexFront);
 			}
-			
+
 			// Update everything
 			auto header = new (newRawPtr) BlockIndexHeader;
 			header->size = pr_blockIndexSize;
 			header->front.store(numberOfFilledSlotsToExpose - 1, std::memory_order_relaxed);
 			header->entries = newBlockIndexEntries;
 			header->prev = pr_blockIndexRaw;		// we link the new block to the old one so we can free it later
-			
+
 			pr_blockIndexFront = j;
 			pr_blockIndexEntries = newBlockIndexEntries;
 			pr_blockIndexRaw = newRawPtr;
 			blockIndex.store(header, std::memory_order_release);
-			
+
 			return true;
 		}
-		
+
 	private:
 		std::atomic<BlockIndexHeader*> blockIndex;
-		
+
 		// To be used by producer only -- consumer must use the ones in referenced by blockIndex
 		size_t pr_blockIndexSlotsUsed;
 		size_t pr_blockIndexSize;
 		size_t pr_blockIndexFront;		// Next slot (not current)
 		BlockIndexEntry* pr_blockIndexEntries;
 		void* pr_blockIndexRaw;
-		
+
 #ifdef MOODYCAMEL_QUEUE_INTERNAL_DEBUG
 	public:
 		ExplicitProducer* nextExplicitProducer;
 	private:
 #endif
-		
+
 #ifdef MCDBGQ_TRACKMEM
 		friend struct MemStats;
 #endif
 	};
-	
-	
+
+
 	//////////////////////////////////
 	// Implicit queue
 	//////////////////////////////////
-	
+
 	struct ImplicitProducer : public ProducerBase
-	{			
+	{
 		ImplicitProducer(ConcurrentQueue* parent_) :
 			ProducerBase(parent_, false),
 			nextBlockIndexCapacity(IMPLICIT_INITIAL_INDEX_SIZE),
@@ -2427,21 +2427,21 @@ private:
 		{
 			new_block_index();
 		}
-		
+
 		~ImplicitProducer()
 		{
 			// Note that since we're in the destructor we can assume that all enqueue/dequeue operations
 			// completed already; this means that all undequeued elements are placed contiguously across
 			// contiguous blocks, and that only the first and last remaining blocks can be only partially
 			// empty (all other remaining blocks must be completely full).
-			
+
 #ifdef MOODYCAMEL_CPP11_THREAD_LOCAL_SUPPORTED
 			// Unregister ourselves for thread termination notification
 			if (!this->inactive.load(std::memory_order_relaxed)) {
 				details::ThreadExitNotifier::unsubscribe(&threadExitListener);
 			}
 #endif
-			
+
 			// Destroy all remaining elements!
 			auto tail = this->tailIndex.load(std::memory_order_relaxed);
 			auto index = this->headIndex.load(std::memory_order_relaxed);
@@ -2454,10 +2454,10 @@ private:
 						// Free the old block
 						this->parent->add_block_to_free_list(block);
 					}
-					
+
 					block = get_block_index_entry_for_index(index)->value.load(std::memory_order_relaxed);
 				}
-				
+
 				((*block)[index])->~T();
 				++index;
 			}
@@ -2467,7 +2467,7 @@ private:
 			if (this->tailBlock != nullptr && (forceFreeLastBlock || (tail & static_cast<index_t>(BLOCK_SIZE - 1)) != 0)) {
 				this->parent->add_block_to_free_list(this->tailBlock);
 			}
-			
+
 			// Destroy block index
 			auto localBlockIndex = blockIndex.load(std::memory_order_relaxed);
 			if (localBlockIndex != nullptr) {
@@ -2482,7 +2482,7 @@ private:
 				} while (localBlockIndex != nullptr);
 			}
 		}
-		
+
 		template<AllocationMode allocMode, typename U>
 		inline bool enqueue(U&& element)
 		{
@@ -2503,7 +2503,7 @@ private:
 				if (!insert_block_index_entry<allocMode>(idxEntry, currentTailIndex)) {
 					return false;
 				}
-				
+
 				// Get ahold of a new block
 				auto newBlock = this->parent->ConcurrentQueue::template requisition_block<allocMode>();
 				if (newBlock == nullptr) {
@@ -2528,25 +2528,25 @@ private:
 						MOODYCAMEL_RETHROW;
 					}
 				}
-				
+
 				// Insert the new block into the index
 				idxEntry->value.store(newBlock, std::memory_order_relaxed);
-				
+
 				this->tailBlock = newBlock;
-				
+
 				MOODYCAMEL_CONSTEXPR_IF (!MOODYCAMEL_NOEXCEPT_CTOR(T, U, new (static_cast<T*>(nullptr)) T(std::forward<U>(element)))) {
 					this->tailIndex.store(newTailIndex, std::memory_order_release);
 					return true;
 				}
 			}
-			
+
 			// Enqueue
 			new ((*this->tailBlock)[currentTailIndex]) T(std::forward<U>(element));
-			
+
 			this->tailIndex.store(newTailIndex, std::memory_order_release);
 			return true;
 		}
-		
+
 		template<typename U>
 		bool dequeue(U& element)
 		{
@@ -2555,19 +2555,19 @@ private:
 			index_t overcommit = this->dequeueOvercommit.load(std::memory_order_relaxed);
 			if (details::circular_less_than<index_t>(this->dequeueOptimisticCount.load(std::memory_order_relaxed) - overcommit, tail)) {
 				std::atomic_thread_fence(std::memory_order_acquire);
-				
+
 				index_t myDequeueCount = this->dequeueOptimisticCount.fetch_add(1, std::memory_order_relaxed);
 				tail = this->tailIndex.load(std::memory_order_acquire);
 				if ((details::likely)(details::circular_less_than<index_t>(myDequeueCount - overcommit, tail))) {
 					index_t index = this->headIndex.fetch_add(1, std::memory_order_acq_rel);
-					
+
 					// Determine which block the element is in
 					auto entry = get_block_index_entry_for_index(index);
-					
+
 					// Dequeue
 					auto block = entry->value.load(std::memory_order_relaxed);
 					auto& el = *((*block)[index]);
-					
+
 					if (!MOODYCAMEL_NOEXCEPT_ASSIGN(T, T&&, element = std::move(el))) {
 #ifdef MCDBGQ_NOLOCKFREE_IMPLICITPRODBLOCKINDEX
 						// Note: Acquiring the mutex with every dequeue instead of only when a block
@@ -2579,7 +2579,7 @@ private:
 							index_t index;
 							BlockIndexEntry* entry;
 							ConcurrentQueue* parent;
-							
+
 							~Guard()
 							{
 								(*block)[index]->~T();
@@ -2607,17 +2607,17 @@ private:
 							this->parent->add_block_to_free_list(block);		// releases the above store
 						}
 					}
-					
+
 					return true;
 				}
 				else {
 					this->dequeueOvercommit.fetch_add(1, std::memory_order_release);
 				}
 			}
-		
+
 			return false;
 		}
-		
+
 #ifdef _MSC_VER
 #pragma warning(push)
 #pragma warning(disable: 4706)  // assignment within conditional expression
@@ -2628,17 +2628,17 @@ private:
 			// First, we need to make sure we have enough room to enqueue all of the elements;
 			// this means pre-allocating blocks and putting them in the block index (but only if
 			// all the allocations succeeded).
-			
+
 			// Note that the tailBlock we start off with may not be owned by us any more;
 			// this happens if it was filled up exactly to the top (setting tailIndex to
 			// the first index of the next block which is not yet allocated), then dequeued
 			// completely (putting it on the free list) before we enqueue again.
-			
+
 			index_t startTailIndex = this->tailIndex.load(std::memory_order_relaxed);
 			auto startBlock = this->tailBlock;
 			Block* firstAllocatedBlock = nullptr;
 			auto endBlock = this->tailBlock;
-			
+
 			// Figure out how many blocks we'll need to allocate, and do so
 			size_t blockBaseDiff = ((startTailIndex + count - 1) & ~static_cast<index_t>(BLOCK_SIZE - 1)) - ((startTailIndex - 1) & ~static_cast<index_t>(BLOCK_SIZE - 1));
 			index_t currentTailIndex = (startTailIndex - 1) & ~static_cast<index_t>(BLOCK_SIZE - 1);
@@ -2649,7 +2649,7 @@ private:
 				do {
 					blockBaseDiff -= static_cast<index_t>(BLOCK_SIZE);
 					currentTailIndex += static_cast<index_t>(BLOCK_SIZE);
-					
+
 					// Find out where we'll be inserting this block in the block index
 					BlockIndexEntry* idxEntry = nullptr;  // initialization here unnecessary but compiler can't always tell
 					Block* newBlock;
@@ -2674,19 +2674,19 @@ private:
 						}
 						this->parent->add_blocks_to_free_list(firstAllocatedBlock);
 						this->tailBlock = startBlock;
-						
+
 						return false;
 					}
-					
+
 #ifdef MCDBGQ_TRACKMEM
 					newBlock->owner = this;
 #endif
 					newBlock->ConcurrentQueue::Block::template reset_empty<implicit_context>();
 					newBlock->next = nullptr;
-					
+
 					// Insert the new block into the index
 					idxEntry->value.store(newBlock, std::memory_order_relaxed);
-					
+
 					// Store the chain of blocks so that we can undo if later allocations fail,
 					// and so that we can find the blocks when we do the actual enqueueing
 					if ((startTailIndex & static_cast<index_t>(BLOCK_SIZE - 1)) != 0 || firstAllocatedBlock != nullptr) {
@@ -2698,7 +2698,7 @@ private:
 					firstAllocatedBlock = firstAllocatedBlock == nullptr ? newBlock : firstAllocatedBlock;
 				} while (blockBaseDiff > 0);
 			}
-			
+
 			// Enqueue, one block at a time
 			index_t newTailIndex = startTailIndex + static_cast<index_t>(count);
 			currentTailIndex = startTailIndex;
@@ -2728,7 +2728,7 @@ private:
 					MOODYCAMEL_CATCH (...) {
 						auto constructedStopIndex = currentTailIndex;
 						auto lastBlockEnqueued = this->tailBlock;
-						
+
 						if (!details::is_trivially_destructible<T>::value) {
 							auto block = startBlock;
 							if ((startTailIndex & static_cast<index_t>(BLOCK_SIZE - 1)) == 0) {
@@ -2749,7 +2749,7 @@ private:
 								block = block->next;
 							}
 						}
-						
+
 						currentTailIndex = (startTailIndex - 1) & ~static_cast<index_t>(BLOCK_SIZE - 1);
 						for (auto block = firstAllocatedBlock; block != nullptr; block = block->next) {
 							currentTailIndex += static_cast<index_t>(BLOCK_SIZE);
@@ -2762,7 +2762,7 @@ private:
 						MOODYCAMEL_RETHROW;
 					}
 				}
-				
+
 				if (this->tailBlock == endBlock) {
 					assert(currentTailIndex == newTailIndex);
 					break;
@@ -2775,7 +2775,7 @@ private:
 #ifdef _MSC_VER
 #pragma warning(pop)
 #endif
-		
+
 		template<typename It>
 		size_t dequeue_bulk(It& itemFirst, size_t max)
 		{
@@ -2785,9 +2785,9 @@ private:
 			if (details::circular_less_than<size_t>(0, desiredCount)) {
 				desiredCount = desiredCount < max ? desiredCount : max;
 				std::atomic_thread_fence(std::memory_order_acquire);
-				
+
 				auto myDequeueCount = this->dequeueOptimisticCount.fetch_add(desiredCount, std::memory_order_relaxed);
-				
+
 				tail = this->tailIndex.load(std::memory_order_acquire);
 				auto actualCount = static_cast<size_t>(tail - (myDequeueCount - overcommit));
 				if (details::circular_less_than<size_t>(0, actualCount)) {
@@ -2795,11 +2795,11 @@ private:
 					if (actualCount < desiredCount) {
 						this->dequeueOvercommit.fetch_add(desiredCount - actualCount, std::memory_order_release);
 					}
-					
+
 					// Get the first index. Note that since there's guaranteed to be at least actualCount elements, this
 					// will never exceed tail.
 					auto firstIndex = this->headIndex.fetch_add(actualCount, std::memory_order_acq_rel);
-					
+
 					// Iterate the blocks and dequeue
 					auto index = firstIndex;
 					BlockIndexHeader* localBlockIndex;
@@ -2808,7 +2808,7 @@ private:
 						auto blockStartIndex = index;
 						index_t endIndex = (index & ~static_cast<index_t>(BLOCK_SIZE - 1)) + static_cast<index_t>(BLOCK_SIZE);
 						endIndex = details::circular_less_than<index_t>(firstIndex + static_cast<index_t>(actualCount), endIndex) ? firstIndex + static_cast<index_t>(actualCount) : endIndex;
-						
+
 						auto entry = localBlockIndex->index[indexIndex];
 						auto block = entry->value.load(std::memory_order_relaxed);
 						if (MOODYCAMEL_NOEXCEPT_ASSIGN(T, T&&, details::deref_noexcept(itemFirst) = std::move((*(*block)[index])))) {
@@ -2836,7 +2836,7 @@ private:
 									while (index != endIndex) {
 										(*block)[index++]->~T();
 									}
-									
+
 									if (block->ConcurrentQueue::Block::template set_many_empty<implicit_context>(blockStartIndex, static_cast<size_t>(endIndex - blockStartIndex))) {
 #ifdef MCDBGQ_NOLOCKFREE_IMPLICITPRODBLOCKINDEX
 										debug::DebugLock lock(mutex);
@@ -2845,12 +2845,12 @@ private:
 										this->parent->add_block_to_free_list(block);
 									}
 									indexIndex = (indexIndex + 1) & (localBlockIndex->capacity - 1);
-									
+
 									blockStartIndex = index;
 									endIndex = (index & ~static_cast<index_t>(BLOCK_SIZE - 1)) + static_cast<index_t>(BLOCK_SIZE);
 									endIndex = details::circular_less_than<index_t>(firstIndex + static_cast<index_t>(actualCount), endIndex) ? firstIndex + static_cast<index_t>(actualCount) : endIndex;
 								} while (index != firstIndex + actualCount);
-								
+
 								MOODYCAMEL_RETHROW;
 							}
 						}
@@ -2867,27 +2867,27 @@ private:
 						}
 						indexIndex = (indexIndex + 1) & (localBlockIndex->capacity - 1);
 					} while (index != firstIndex + actualCount);
-					
+
 					return actualCount;
 				}
 				else {
 					this->dequeueOvercommit.fetch_add(desiredCount, std::memory_order_release);
 				}
 			}
-			
+
 			return 0;
 		}
-		
+
 	private:
 		// The block size must be > 1, so any number with the low bit set is an invalid block base index
 		static const index_t INVALID_BLOCK_BASE = 1;
-		
+
 		struct BlockIndexEntry
 		{
 			std::atomic<index_t> key;
 			std::atomic<Block*> value;
 		};
-		
+
 		struct BlockIndexHeader
 		{
 			size_t capacity;
@@ -2896,7 +2896,7 @@ private:
 			BlockIndexEntry** index;
 			BlockIndexHeader* prev;
 		};
-		
+
 		template<AllocationMode allocMode>
 		inline bool insert_block_index_entry(BlockIndexEntry*& idxEntry, index_t blockStartIndex)
 		{
@@ -2908,12 +2908,12 @@ private:
 			idxEntry = localBlockIndex->index[newTail];
 			if (idxEntry->key.load(std::memory_order_relaxed) == INVALID_BLOCK_BASE ||
 				idxEntry->value.load(std::memory_order_relaxed) == nullptr) {
-				
+
 				idxEntry->key.store(blockStartIndex, std::memory_order_relaxed);
 				localBlockIndex->tail.store(newTail, std::memory_order_release);
 				return true;
 			}
-			
+
 			// No room in the old block index, try to allocate another one!
 			MOODYCAMEL_CONSTEXPR_IF (allocMode == CannotAlloc) {
 				return false;
@@ -2931,20 +2931,20 @@ private:
 				return true;
 			}
 		}
-		
+
 		inline void rewind_block_index_tail()
 		{
 			auto localBlockIndex = blockIndex.load(std::memory_order_relaxed);
 			localBlockIndex->tail.store((localBlockIndex->tail.load(std::memory_order_relaxed) - 1) & (localBlockIndex->capacity - 1), std::memory_order_relaxed);
 		}
-		
+
 		inline BlockIndexEntry* get_block_index_entry_for_index(index_t index) const
 		{
 			BlockIndexHeader* localBlockIndex;
 			auto idx = get_block_index_index_for_index(index, localBlockIndex);
 			return localBlockIndex->index[idx];
 		}
-		
+
 		inline size_t get_block_index_index_for_index(index_t index, BlockIndexHeader*& localBlockIndex) const
 		{
 #ifdef MCDBGQ_NOLOCKFREE_IMPLICITPRODBLOCKINDEX
@@ -2962,7 +2962,7 @@ private:
 			assert(localBlockIndex->index[idx]->key.load(std::memory_order_relaxed) == index && localBlockIndex->index[idx]->value.load(std::memory_order_relaxed) != nullptr);
 			return idx;
 		}
-		
+
 		bool new_block_index()
 		{
 			auto prev = blockIndex.load(std::memory_order_relaxed);
@@ -2975,7 +2975,7 @@ private:
 			if (raw == nullptr) {
 				return false;
 			}
-			
+
 			auto header = new (raw) BlockIndexHeader;
 			auto entries = reinterpret_cast<BlockIndexEntry*>(details::align_for<BlockIndexEntry>(raw + sizeof(BlockIndexHeader)));
 			auto index = reinterpret_cast<BlockIndexEntry**>(details::align_for<BlockIndexEntry*>(reinterpret_cast<char*>(entries) + sizeof(BlockIndexEntry) * entryCount));
@@ -2999,14 +2999,14 @@ private:
 			header->index = index;
 			header->capacity = nextBlockIndexCapacity;
 			header->tail.store((prevCapacity - 1) & (nextBlockIndexCapacity - 1), std::memory_order_relaxed);
-			
+
 			blockIndex.store(header, std::memory_order_release);
-			
+
 			nextBlockIndexCapacity <<= 1;
-			
+
 			return true;
 		}
-		
+
 	private:
 		size_t nextBlockIndexCapacity;
 		std::atomic<BlockIndexHeader*> blockIndex;
@@ -3016,7 +3016,7 @@ private:
 		details::ThreadExitListener threadExitListener;
 	private:
 #endif
-		
+
 #ifdef MOODYCAMEL_QUEUE_INTERNAL_DEBUG
 	public:
 		ImplicitProducer* nextImplicitProducer;
@@ -3030,12 +3030,12 @@ private:
 		friend struct MemStats;
 #endif
 	};
-	
-	
+
+
 	//////////////////////////////////
 	// Block pool manipulation
 	//////////////////////////////////
-	
+
 	void populate_initial_block_list(size_t blockCount)
 	{
 		initialBlockPoolSize = blockCount;
@@ -3043,7 +3043,7 @@ private:
 			initialBlockPool = nullptr;
 			return;
 		}
-		
+
 		initialBlockPool = create_array<Block>(blockCount);
 		if (initialBlockPool == nullptr) {
 			initialBlockPoolSize = 0;
@@ -3052,18 +3052,18 @@ private:
 			initialBlockPool[i].dynamicallyAllocated = false;
 		}
 	}
-	
+
 	inline Block* try_get_block_from_initial_pool()
 	{
 		if (initialBlockPoolIndex.load(std::memory_order_relaxed) >= initialBlockPoolSize) {
 			return nullptr;
 		}
-		
+
 		auto index = initialBlockPoolIndex.fetch_add(1, std::memory_order_relaxed);
-		
+
 		return index < initialBlockPoolSize ? (initialBlockPool + index) : nullptr;
 	}
-	
+
 	inline void add_block_to_free_list(Block* block)
 	{
 #ifdef MCDBGQ_TRACKMEM
@@ -3076,7 +3076,7 @@ private:
 			freeList.add(block);
 		}
 	}
-	
+
 	inline void add_blocks_to_free_list(Block* block)
 	{
 		while (block != nullptr) {
@@ -3085,12 +3085,12 @@ private:
 			block = next;
 		}
 	}
-	
+
 	inline Block* try_get_block_from_free_list()
 	{
 		return freeList.try_get();
 	}
-	
+
 	// Gets a free block from one of the memory pools, or allocates a new one (if applicable)
 	template<AllocationMode canAlloc>
 	Block* requisition_block()
@@ -3099,12 +3099,12 @@ private:
 		if (block != nullptr) {
 			return block;
 		}
-		
+
 		block = try_get_block_from_free_list();
 		if (block != nullptr) {
 			return block;
 		}
-		
+
 		MOODYCAMEL_CONSTEXPR_IF (canAlloc == CanAlloc) {
 			return create<Block>();
 		}
@@ -3112,7 +3112,7 @@ private:
 			return nullptr;
 		}
 	}
-	
+
 
 #ifdef MCDBGQ_TRACKMEM
 	public:
@@ -3129,28 +3129,28 @@ private:
 			size_t queueClassBytes;
 			size_t implicitBlockIndexBytes;
 			size_t explicitBlockIndexBytes;
-			
+
 			friend class ConcurrentQueue;
-			
+
 		private:
 			static MemStats getFor(ConcurrentQueue* q)
 			{
 				MemStats stats = { 0 };
-				
+
 				stats.elementsEnqueued = q->size_approx();
-			
+
 				auto block = q->freeList.head_unsafe();
 				while (block != nullptr) {
 					++stats.allocatedBlocks;
 					++stats.freeBlocks;
 					block = block->freeListNext.load(std::memory_order_relaxed);
 				}
-				
+
 				for (auto ptr = q->producerListTail.load(std::memory_order_acquire); ptr != nullptr; ptr = ptr->next_prod()) {
 					bool implicit = dynamic_cast<ImplicitProducer*>(ptr) != nullptr;
 					stats.implicitProducers += implicit ? 1 : 0;
 					stats.explicitProducers += implicit ? 0 : 1;
-					
+
 					if (implicit) {
 						auto prod = static_cast<ImplicitProducer*>(ptr);
 						stats.queueClassBytes += sizeof(ImplicitProducer);
@@ -3198,18 +3198,18 @@ private:
 						}
 					}
 				}
-				
+
 				auto freeOnInitialPool = q->initialBlockPoolIndex.load(std::memory_order_relaxed) >= q->initialBlockPoolSize ? 0 : q->initialBlockPoolSize - q->initialBlockPoolIndex.load(std::memory_order_relaxed);
 				stats.allocatedBlocks += freeOnInitialPool;
 				stats.freeBlocks += freeOnInitialPool;
-				
+
 				stats.blockClassBytes = sizeof(Block) * stats.allocatedBlocks;
 				stats.queueClassBytes += sizeof(ConcurrentQueue);
-				
+
 				return stats;
 			}
 		};
-		
+
 		// For debugging only. Not thread-safe.
 		MemStats getMemStats()
 		{
@@ -3218,12 +3218,12 @@ private:
 	private:
 		friend struct MemStats;
 #endif
-	
-	
+
+
 	//////////////////////////////////
 	// Producer list manipulation
-	//////////////////////////////////	
-	
+	//////////////////////////////////
+
 	ProducerBase* recycle_or_create_producer(bool isExplicit)
 	{
 #ifdef MCDBGQ_NOLOCKFREE_IMPLICITPRODHASH
@@ -3242,22 +3242,22 @@ private:
 
 		return add_producer(isExplicit ? static_cast<ProducerBase*>(create<ExplicitProducer>(this)) : create<ImplicitProducer>(this));
 	}
-	
+
 	ProducerBase* add_producer(ProducerBase* producer)
 	{
 		// Handle failed memory allocation
 		if (producer == nullptr) {
 			return nullptr;
 		}
-		
+
 		producerCount.fetch_add(1, std::memory_order_relaxed);
-		
+
 		// Add it to the lock-free list
 		auto prevTail = producerListTail.load(std::memory_order_relaxed);
 		do {
 			producer->next = prevTail;
 		} while (!producerListTail.compare_exchange_weak(prevTail, producer, std::memory_order_release, std::memory_order_relaxed));
-		
+
 #ifdef MOODYCAMEL_QUEUE_INTERNAL_DEBUG
 		if (producer->isExplicit) {
 			auto prevTailExplicit = explicitProducers.load(std::memory_order_relaxed);
@@ -3272,10 +3272,10 @@ private:
 			} while (!implicitProducers.compare_exchange_weak(prevTailImplicit, static_cast<ImplicitProducer*>(producer), std::memory_order_release, std::memory_order_relaxed));
 		}
 #endif
-		
+
 		return producer;
 	}
-	
+
 	void reown_producers()
 	{
 		// After another instance is moved-into/swapped-with this one, all the
@@ -3285,31 +3285,31 @@ private:
 			ptr->parent = this;
 		}
 	}
-	
-	
+
+
 	//////////////////////////////////
 	// Implicit producer hash
 	//////////////////////////////////
-	
+
 	struct ImplicitProducerKVP
 	{
 		std::atomic<details::thread_id_t> key;
 		ImplicitProducer* value;		// No need for atomicity since it's only read by the thread that sets it in the first place
-		
+
 		ImplicitProducerKVP() : value(nullptr) { }
-		
+
 		ImplicitProducerKVP(ImplicitProducerKVP&& other) MOODYCAMEL_NOEXCEPT
 		{
 			key.store(other.key.load(std::memory_order_relaxed), std::memory_order_relaxed);
 			value = other.value;
 		}
-		
+
 		inline ImplicitProducerKVP& operator=(ImplicitProducerKVP&& other) MOODYCAMEL_NOEXCEPT
 		{
 			swap(other);
 			return *this;
 		}
-		
+
 		inline void swap(ImplicitProducerKVP& other) MOODYCAMEL_NOEXCEPT
 		{
 			if (this != &other) {
@@ -3318,17 +3318,17 @@ private:
 			}
 		}
 	};
-	
+
 	template<typename XT, typename XTraits>
 	friend void moodycamel::swap(typename ConcurrentQueue<XT, XTraits>::ImplicitProducerKVP&, typename ConcurrentQueue<XT, XTraits>::ImplicitProducerKVP&) MOODYCAMEL_NOEXCEPT;
-	
+
 	struct ImplicitProducerHash
 	{
 		size_t capacity;
 		ImplicitProducerKVP* entries;
 		ImplicitProducerHash* prev;
 	};
-	
+
 	inline void populate_initial_implicit_producer_hash()
 	{
 		MOODYCAMEL_CONSTEXPR_IF (INITIAL_IMPLICIT_PRODUCER_HASH_SIZE == 0) {
@@ -3346,7 +3346,7 @@ private:
 			implicitProducerHash.store(hash, std::memory_order_relaxed);
 		}
 	}
-	
+
 	void swap_implicit_producer_hashes(ConcurrentQueue& other)
 	{
 		MOODYCAMEL_CONSTEXPR_IF (INITIAL_IMPLICIT_PRODUCER_HASH_SIZE == 0) {
@@ -3357,9 +3357,9 @@ private:
 			initialImplicitProducerHashEntries.swap(other.initialImplicitProducerHashEntries);
 			initialImplicitProducerHash.entries = &initialImplicitProducerHashEntries[0];
 			other.initialImplicitProducerHash.entries = &other.initialImplicitProducerHashEntries[0];
-			
+
 			details::swap_relaxed(implicitProducerHashCount, other.implicitProducerHashCount);
-			
+
 			details::swap_relaxed(implicitProducerHash, other.implicitProducerHash);
 			if (implicitProducerHash.load(std::memory_order_relaxed) == &other.initialImplicitProducerHash) {
 				implicitProducerHash.store(&initialImplicitProducerHash, std::memory_order_relaxed);
@@ -3383,27 +3383,27 @@ private:
 			}
 		}
 	}
-	
+
 	// Only fails (returns nullptr) if memory allocation fails
 	ImplicitProducer* get_or_add_implicit_producer()
 	{
 		// Note that since the data is essentially thread-local (key is thread ID),
 		// there's a reduced need for fences (memory ordering is already consistent
 		// for any individual thread), except for the current table itself.
-		
+
 		// Start by looking for the thread ID in the current and all previous hash tables.
 		// If it's not found, it must not be in there yet, since this same thread would
 		// have added it previously to one of the tables that we traversed.
-		
+
 		// Code and algorithm adapted from http://preshing.com/20130605/the-worlds-simplest-lock-free-hash-table
-		
+
 #ifdef MCDBGQ_NOLOCKFREE_IMPLICITPRODHASH
 		debug::DebugLock lock(implicitProdMutex);
 #endif
-		
+
 		auto id = details::thread_id();
 		auto hashedId = details::hash_thread_id(id);
-		
+
 		auto mainHash = implicitProducerHash.load(std::memory_order_acquire);
 		assert(mainHash != nullptr);  // silence clang-tidy and MSVC warnings (hash cannot be null)
 		for (auto hash = mainHash; hash != nullptr; hash = hash->prev) {
@@ -3411,7 +3411,7 @@ private:
 			auto index = hashedId;
 			while (true) {		// Not an infinite loop because at least one slot is free in the hash table
 				index &= hash->capacity - 1u;
-				
+
 				auto probedKey = hash->entries[index].key.load(std::memory_order_relaxed);
 				if (probedKey == id) {
 					// Found it! If we had to search several hashes deep, though, we should lazily add it
@@ -3438,7 +3438,7 @@ private:
 							++index;
 						}
 					}
-					
+
 					return value;
 				}
 				if (probedKey == details::invalid_thread_id) {
@@ -3447,7 +3447,7 @@ private:
 				++index;
 			}
 		}
-		
+
 		// Insert!
 		auto newCount = 1 + implicitProducerHashCount.fetch_add(1, std::memory_order_relaxed);
 		while (true) {
@@ -3470,7 +3470,7 @@ private:
 						implicitProducerHashResizeInProgress.clear(std::memory_order_relaxed);
 						return nullptr;
 					}
-					
+
 					auto newHash = new (raw) ImplicitProducerHash;
 					newHash->capacity = static_cast<size_t>(newCapacity);
 					newHash->entries = reinterpret_cast<ImplicitProducerKVP*>(details::align_for<ImplicitProducerKVP>(raw + sizeof(ImplicitProducerHash)));
@@ -3487,7 +3487,7 @@ private:
 					implicitProducerHashResizeInProgress.clear(std::memory_order_release);
 				}
 			}
-			
+
 			// If it's < three-quarters full, add to the old one anyway so that we don't have to wait for the next table
 			// to finish being allocated by another thread (and if we just finished allocating above, the condition will
 			// always be true)
@@ -3497,13 +3497,13 @@ private:
 					implicitProducerHashCount.fetch_sub(1, std::memory_order_relaxed);
 					return nullptr;
 				}
-				
+
 #ifdef MOODYCAMEL_CPP11_THREAD_LOCAL_SUPPORTED
 				producer->threadExitListener.callback = &ConcurrentQueue::implicit_producer_thread_exited_callback;
 				producer->threadExitListener.userData = producer;
 				details::ThreadExitNotifier::subscribe(&producer->threadExitListener);
 #endif
-				
+
 				auto index = hashedId;
 				while (true) {
 					index &= mainHash->capacity - 1u;
@@ -3524,14 +3524,14 @@ private:
 				}
 				return producer;
 			}
-			
+
 			// Hmm, the old hash is quite full and somebody else is busy allocating a new one.
 			// We need to wait for the allocating thread to finish (if it succeeds, we add, if not,
 			// we try to allocate ourselves).
 			mainHash = implicitProducerHash.load(std::memory_order_acquire);
 		}
 	}
-	
+
 #ifdef MOODYCAMEL_CPP11_THREAD_LOCAL_SUPPORTED
 	void implicit_producer_thread_exited(ImplicitProducer* producer)
 	{
@@ -3544,7 +3544,7 @@ private:
 		auto id = details::thread_id();
 		auto hashedId = details::hash_thread_id(id);
 		details::thread_id_t probedKey;
-		
+
 		// We need to traverse all the hashes just in case other threads aren't on the current one yet and are
 		// trying to add an entry thinking there's a free slot (because they reused a producer)
 		for (; hash != nullptr; hash = hash->prev) {
@@ -3558,11 +3558,11 @@ private:
 				++index;
 			} while (probedKey != details::invalid_thread_id);		// Can happen if the hash has changed but we weren't put back in it yet, or if we weren't added to this hash in the first place
 		}
-		
+
 		// Mark the queue as being recyclable
 		producer->inactive.store(true, std::memory_order_release);
 	}
-	
+
 	static void implicit_producer_thread_exited_callback(void* userData)
 	{
 		auto producer = static_cast<ImplicitProducer*>(userData);
@@ -3570,7 +3570,7 @@ private:
 		queue->implicit_producer_thread_exited(producer);
 	}
 #endif
-	
+
 	//////////////////////////////////
 	// Utility functions
 	//////////////////////////////////
@@ -3649,30 +3649,30 @@ private:
 private:
 	std::atomic<ProducerBase*> producerListTail;
 	std::atomic<std::uint32_t> producerCount;
-	
+
 	std::atomic<size_t> initialBlockPoolIndex;
 	Block* initialBlockPool;
 	size_t initialBlockPoolSize;
-	
+
 #ifndef MCDBGQ_USEDEBUGFREELIST
 	FreeList<Block> freeList;
 #else
 	debug::DebugFreeList<Block> freeList;
 #endif
-	
+
 	std::atomic<ImplicitProducerHash*> implicitProducerHash;
 	std::atomic<size_t> implicitProducerHashCount;		// Number of slots logically used
 	ImplicitProducerHash initialImplicitProducerHash;
 	std::array<ImplicitProducerKVP, INITIAL_IMPLICIT_PRODUCER_HASH_SIZE> initialImplicitProducerHashEntries;
 	std::atomic_flag implicitProducerHashResizeInProgress;
-	
+
 	std::atomic<std::uint32_t> nextExplicitConsumerId;
 	std::atomic<std::uint32_t> globalExplicitConsumerOffset;
-	
+
 #ifdef MCDBGQ_NOLOCKFREE_IMPLICITPRODHASH
 	debug::DebugMutex implicitProdMutex;
 #endif
-	
+
 #ifdef MOODYCAMEL_QUEUE_INTERNAL_DEBUG
 	std::atomic<ExplicitProducer*> explicitProducers;
 	std::atomic<ImplicitProducer*> implicitProducers;

--- a/moodycamel/lightweightsemaphore.h
+++ b/moodycamel/lightweightsemaphore.h
@@ -1,5 +1,5 @@
 // Provides an efficient implementation of a semaphore (LightweightSemaphore).
-// This is an extension of Jeff Preshing's sempahore implementation (licensed 
+// This is an extension of Jeff Preshing's semaphore implementation (licensed
 // under the terms of its separate zlib license) that has been adapted and
 // extended by Cameron Desrochers.
 
@@ -65,7 +65,7 @@ class Semaphore
 {
 private:
 	void* m_hSema;
-	
+
 	Semaphore(const Semaphore& other) MOODYCAMEL_DELETE_FUNCTION;
 	Semaphore& operator=(const Semaphore& other) MOODYCAMEL_DELETE_FUNCTION;
 
@@ -88,12 +88,12 @@ public:
 		const unsigned long infinite = 0xffffffff;
 		return WaitForSingleObject(m_hSema, infinite) == 0;
 	}
-	
+
 	bool try_wait()
 	{
 		return WaitForSingleObject(m_hSema, 0) == 0;
 	}
-	
+
 	bool timed_wait(std::uint64_t usecs)
 	{
 		return WaitForSingleObject(m_hSema, (unsigned long)(usecs / 1000)) == 0;
@@ -107,7 +107,7 @@ public:
 #elif defined(__MACH__)
 //---------------------------------------------------------
 // Semaphore (Apple iOS and OSX)
-// Can't use POSIX semaphores due to http://lists.apple.com/archives/darwin-kernel/2009/Apr/msg00010.html
+// Can't use POSIX semaphores due to https://lists.apple.com/archives/darwin-kernel/2009/Apr/msg00010.html
 //---------------------------------------------------------
 class Semaphore
 {
@@ -135,12 +135,12 @@ public:
 	{
 		return semaphore_wait(m_sema) == KERN_SUCCESS;
 	}
-	
+
 	bool try_wait()
 	{
 		return timed_wait(0);
 	}
-	
+
 	bool timed_wait(std::uint64_t timeout_usecs)
 	{
 		mach_timespec_t ts;
@@ -193,7 +193,7 @@ public:
 
 	bool wait()
 	{
-		// http://stackoverflow.com/questions/2013181/gdb-causes-sem-wait-to-fail-with-eintr-error
+		// https://stackoverflow.com/questions/2013181/gdb-causes-sem-wait-to-fail-with-eintr-error
 		int rc;
 		do {
 			rc = sem_wait(&m_sema);
@@ -396,7 +396,7 @@ public:
 			result = waitManyWithPartialSpinning(max, timeout_usecs);
 		return result;
 	}
-	
+
 	ssize_t waitMany(ssize_t max)
 	{
 		ssize_t result = waitMany(max, -1);
@@ -414,7 +414,7 @@ public:
 			m_sema.signal((int)toRelease);
 		}
 	}
-	
+
 	std::size_t availableApprox() const
 	{
 		ssize_t count = m_count.load(std::memory_order_relaxed);

--- a/packaging/systemd/README
+++ b/packaging/systemd/README
@@ -2,7 +2,7 @@ Kismet Service (and Debug Service)
 
 # Purpose
 
-    The Kismet service runs Kismet, via systemd.  For running Kismet under full debug mode
+    The Kismet service runs Kismet, via systemd. For running Kismet under full debug mode
     (for helping with development or tracking down errors), see the README in the
     kismet_debug/ directory.
 
@@ -17,12 +17,12 @@ Kismet Service (and Debug Service)
     By default, the Kismet systemd service runs Kismet as root; this is NOT best practices
     but it is the only user consistently available.
 
-    It is STONGLY recommended that you install Kismet as suid-root via `make suidinstall`,
-    and that you run Kismet as a non-privileged user.  Kismet will then limit root 
+    It is STRONGLY recommended that you install Kismet as suid-root via `make suidinstall`,
+    and that you run Kismet as a non-privileged user. Kismet will then limit root
     access to the capture binaries which control individual interfaces.
 
     To set up Kismet to run as a user, first follow the install directions in the Kismet
-    README file, and install the Kismet systemd service as above.  Then, use the
+    README file, and install the Kismet systemd service as above. Then, use the
     `systemctl edit` command to configure the Kismet server; for instance if you want to
     run Kismet as the user 'kismet':
 
@@ -34,8 +34,8 @@ Kismet Service (and Debug Service)
         User=kismet
         Group=kismet
 
-    and save.  Now systemd will start Kismet as the 'kismet' user.  If you want to 
-    automatically start Kismet as some other user (such as the one you normally log in as), 
+    and save. Now systemd will start Kismet as the 'kismet' user. If you want to
+    automatically start Kismet as some other user (such as the one you normally log in as),
     put that user in the User= line.
 
 # Activating
@@ -47,5 +47,3 @@ Kismet Service (and Debug Service)
     To start Kismet by default on boot:
 
         $ sudo systemctl enable kismet
-
-

--- a/packaging/systemd/kismet.service.in
+++ b/packaging/systemd/kismet.service.in
@@ -14,4 +14,3 @@ Restart=always
 
 [Install]
 WantedBy=multi-user.target
-

--- a/plugin-alertsyslog/README
+++ b/plugin-alertsyslog/README
@@ -45,4 +45,3 @@ Kismet-ALERTSYSLOG
 
     Once the plugin is loaded, Kismet will automatically log alerts to
     syslog.
-

--- a/plugin-dashboard/README
+++ b/plugin-dashboard/README
@@ -13,4 +13,3 @@ make plugins-install
 and accessed via:
 
 http://localhost:2501/plugin/dashboard/
-

--- a/plugin-demo-eventbus/README
+++ b/plugin-demo-eventbus/README
@@ -2,7 +2,6 @@ Kismet-HTTPPROXYTEST
 
 This plugin is a demo of the external tool / proxy framework
 
-
 Installing:
 
 $ sudo su
@@ -20,5 +19,3 @@ or installable via pip3:
 ```bash
 $ pip3 install python-kismet-external
 ```
-
-

--- a/plugin-demo-externalhttp/README
+++ b/plugin-demo-externalhttp/README
@@ -2,7 +2,6 @@ Kismet-HTTPPROXYTEST
 
 This plugin is a demo of the external tool / proxy framework
 
-
 Installing:
 
 $ sudo su
@@ -20,5 +19,3 @@ or installable via pip3:
 ```bash
 $ pip3 install python-kismet-external
 ```
-
-

--- a/plugin-demo-webonly/README
+++ b/plugin-demo-webonly/README
@@ -9,4 +9,3 @@ structured and provides the very basic Makefile needed to install it.
 
 For more information on how to write plugins and interface with the Kismet
 web ui framework, look at docs/dev/
-

--- a/protobuf_definitions/eventbus.proto
+++ b/protobuf_definitions/eventbus.proto
@@ -16,13 +16,13 @@ message EventbusEvent {
     required string event_json = 1;
 }
 
-// Registering event listeners causes the eventbus to send an event record each time a 
+// Registering event listeners causes the eventbus to send an event record each time a
 // matching type is sent.  A type of '*' receives all events.
 message EventbusRegisterListener {
     repeated string event = 1;
 }
 
-// Publish an event; remotely pubished events must not overlap internal events and must be
+// Publish an event; remotely published events must not overlap internal events and must be
 // limited to pure-json data; the content of a remote published event will not be translated
 // to a complex C++ object.
 // event_content_json will be published in the kismet event as event_content["kismet.eventbus.event_json"]

--- a/strict_fstream.hpp
+++ b/strict_fstream.hpp
@@ -30,7 +30,7 @@ namespace strict_fstream
 {
 
 /// Overload of error-reporting function, to enable use with VS.
-/// Ref: http://stackoverflow.com/a/901316/717706
+/// Ref: https://stackoverflow.com/a/901316/717706
 static std::string strerror()
 {
     std::string buff(80, '\0');

--- a/tools/create_oui_db.py
+++ b/tools/create_oui_db.py
@@ -9,7 +9,7 @@ import requests
 manufs = []
 
 # Original IEEE URI
-OUIURI = "http://standards-oui.ieee.org/oui.txt"
+OUIURI = "https://standards-oui.ieee.org/oui.txt"
 
 # Sanitized and cleaned up maintained version
 # OUIURI = "http://linuxnet.ca/ieee/oui.txt"
@@ -19,7 +19,7 @@ with requests.get(OUIURI) as r:
         l = rl.decode('UTF-8')
         p = re.compile("([0-9A-F]{2}-[0-9A-F]{2}-[0-9A-F]{2}) +\(hex\)\t+(.*)")
         m = p.match(l)
-        
+
         if m is not None and len(m.groups()) == 2:
             oui = m.group(1).replace("-", ":")
             manufs.append("{}\t{}".format(oui, m.group(2)))
@@ -30,4 +30,4 @@ manufs.sort()
 
 for m in manufs:
     print(m)
-    
+

--- a/unordered_dense.h
+++ b/unordered_dense.h
@@ -154,7 +154,7 @@ namespace detail {
 
 // This is a stripped-down implementation of wyhash: https://github.com/wangyi-fudan/wyhash
 // No big-endian support (because different values on different machines don't matter),
-// hardcodes seed and the secret, reformattes the code, and clang-tidy fixes.
+// hardcodes seed and the secret, reformats the code, and clang-tidy fixes.
 namespace detail::wyhash {
 
 static inline void mum(uint64_t* a, uint64_t* b) {

--- a/xxhash.cc
+++ b/xxhash.cc
@@ -46,7 +46,7 @@
  * Method 2 : direct access. This method doesn't depend on compiler but violate C standard.
  *            It can generate buggy code on targets which do not support unaligned memory accesses.
  *            But in some circumstances, it's the only known way to get the most performance (ie GCC + ARMv6)
- * See http://stackoverflow.com/a/32095106/646947 for details.
+ * See https://stackoverflow.com/a/32095106/646947 for details.
  * Prefer these methods in priority order (0 > 1 > 2)
  */
 #ifndef XXH_FORCE_MEMORY_ACCESS   /* can be defined externally, on command line for example */
@@ -169,7 +169,7 @@ static U32 XXH_read32(const void* ptr) { return ((const unalign*)ptr)->u32; }
 #else
 
 /* portable and safe solution. Generally efficient.
- * see : http://stackoverflow.com/a/32095106/646947
+ * see : https://stackoverflow.com/a/32095106/646947
  */
 static U32 XXH_read32(const void* memPtr)
 {
@@ -611,7 +611,7 @@ static U64 XXH_read64(const void* ptr) { return ((const unalign64*)ptr)->u64; }
 #else
 
 /* portable and safe solution. Generally efficient.
- * see : http://stackoverflow.com/a/32095106/646947
+ * see : https://stackoverflow.com/a/32095106/646947
  */
 
 static U64 XXH_read64(const void* memPtr)

--- a/zstr.hpp
+++ b/zstr.hpp
@@ -11,7 +11,7 @@
 //---------------------------------------------------------
 
 // Reference:
-// http://stackoverflow.com/questions/14086417/how-to-write-custom-input-stream-in-c
+// https://stackoverflow.com/questions/14086417/how-to-write-custom-input-stream-in-c
 
 #ifndef __ZSTR_HPP
 #define __ZSTR_HPP
@@ -165,7 +165,7 @@ public:
                     unsigned char b1 = *reinterpret_cast< unsigned char * >(in_buff_start + 1);
                     // Ref:
                     // http://en.wikipedia.org/wiki/Gzip
-                    // http://stackoverflow.com/questions/9050260/what-does-a-zlib-header-look-like
+                    // https://stackoverflow.com/questions/9050260/what-does-a-zlib-header-look-like
                     is_text = ! (in_buff_start + 2 <= in_buff_end
                                  && ((b0 == 0x1F && b1 == 0x8B)         // gzip header
                                      || (b0 == 0x78 && (b1 == 0x01      // zlib header


### PR DESCRIPTION
Minor fixes
  - Remove empty lines in readmes
  - http -> https in URLs where they can be
  - Fix a few typos