### PR TITLE
Patched undeclared stderr. I think rtl-sdr.h was importing stdio before.

### DIFF
--- a/capture_sdr_rtladsb_v2/capture_sdr_rtladsb_v2.c
+++ b/capture_sdr_rtladsb_v2/capture_sdr_rtladsb_v2.c
@@ -65,7 +65,7 @@
 #include <sys/stat.h>
 
 #include <stdint.h>
-
+#include <stdio.h>
 #include <rtl-sdr.h>
 
 #include "../capture_framework.h"


### PR DESCRIPTION
```
capture_sdr_rtladsb_v2.c:920:9: note: include ‘<stdio.h>’ or provide a declaration of ‘fprintf’
capture_sdr_rtladsb_v2.c:920:17: error: ‘stderr’ undeclared (first use in this function)
  920 |         fprintf(stderr, "FATAL: Could not allocate basic handler data, your system "
      |                 ^~~~~~
capture_sdr_rtladsb_v2.c:920:17: note: ‘stderr’ is defined in header ‘<stdio.h>’; did you forget to ‘#include <stdio.h>’?
At top level:
```