### PR TITLE
MQTT Datasource Work

### DIFF
--- a/datasource_mqtt.cc
+++ b/datasource_mqtt.cc
@@ -20,7 +20,6 @@
 #include "kis_datasource.h"
 #include "datasource_mqtt.h"
 #include "alertracker.h"
-#include "packet.h"
 
 #ifdef HAVE_LIBMOSQUITTO
 
@@ -479,9 +478,6 @@ void kis_datasource_mqtt::open_interface(std::string in_definition, unsigned int
             auto jsoninfo = ds->packetchain->new_packet_component<kis_json_packinfo>();
             jsoninfo->type = ds->json_type_;
             jsoninfo->json_string = json_string;
-
-            // _MSG_DEBUG("JSON Type: {}", jsoninfo->type);
-            // _MSG_DEBUG("JSON String: {}", jsoninfo->json_string);
 
             packet->insert(ds->pack_comp_json, jsoninfo);
 

--- a/datasource_mqtt.cc
+++ b/datasource_mqtt.cc
@@ -416,17 +416,17 @@ void kis_datasource_mqtt::open_interface(std::string in_definition, unsigned int
 
             double lat = json.value("lat", 0.0);
             double lon = json.value("lon", 0.0);
-            double alt = json.value("alt", 0.0);
-            double speed = json.value("spd", 0.0);
 
             if (lat != 0.0 && lon != 0.0) {
+                double alt = json.value("alt", 0.0);
+
                 auto gpsinfo = std::make_shared<kis_gps_packinfo>();
 
                 gpsinfo->lat = lat;
                 gpsinfo->lon = lon;
                 gpsinfo->alt = alt;
                 gpsinfo->fix = (alt != 0.0) ? 3 : 2;
-                gpsinfo->speed = speed;
+                gpsinfo->speed = json.value("spd", 0.0);
 
                 packet->insert(ds->pack_comp_gps, gpsinfo);
             }
@@ -476,6 +476,7 @@ void kis_datasource_mqtt::open_interface(std::string in_definition, unsigned int
             // --- Prepare JSON for parsing ---
 
             auto jsoninfo = ds->packetchain->new_packet_component<kis_json_packinfo>();
+            
             jsoninfo->type = ds->json_type_;
             jsoninfo->json_string = json_string;
 


### PR DESCRIPTION
- Added parsing the JSON payload to fill required metadata for datasources to parse packets properly (wish there was a way to prevent JSON parsing twice, but it probably requires major refact in the datasources?)
- Added a helper function to reduce repeating code
- Changed comparisons to use .empty()

Tested with MQTT messages from `readsb`, `Network Survey App` WiFi and Bluetooth transformed into expected JSON using Node-RED. I haven't tested against `rtl_433` since there aren't sensors around me, but any JSON payload formatted the way a Kismet datasource expects it to be should be supported.

Example configuration/Node-RED flows: [https://hobobandy.tips/guides/mqtt/kismet-mqtt/](https://hobobandy.tips/guides/mqtt/kismet-mqtt/)