### PR TITLE
Update capture_catsniffer_zigbee.c

### DIFF
--- a/capture_catsniffer_zigbee/capture_catsniffer_zigbee.c
+++ b/capture_catsniffer_zigbee/capture_catsniffer_zigbee.c
@@ -1,4 +1,4 @@
-//Usage: sudo ./kismet_cap_catsniffer_zigbee  --source=catsniffer:device=/dev/ttyACM0 --connect localhost:3501 --tcp --disable-retry
+//Usage: sudo ./kismet_cap_catsniffer_zigbee  --source=catsniffer_zigbee:device=/dev/ttyACM0 --connect localhost:3501 --tcp --disable-retry
 
 #define _GNU_SOURCE
 


### PR DESCRIPTION
Example syntax "--source=catsniffer" was incorrect. Should be "--source=catsniffer_zigbee". Also needs to be updated in the wiki for running the source.