### PR TITLE
Add BLE PDU type storage to device tracker

### DIFF
--- a/http_data/js/kismet.ui.btle.js
+++ b/http_data/js/kismet.ui.btle.js
@@ -64,6 +64,24 @@ kismet_ui.AddDeviceDetail("btle", "BTLE", 0, {
                 },
                 help: "Device supports BT classic BR/EDR modes as a host",
             },
+            {
+                field: "btle.device/btle.device.pdu_type",
+                title: "PDU Type",
+                draw: function(opts) {
+                    var pdu_types = {
+                        0x0: "ADV_IND (Connectable)",
+                        0x1: "ADV_DIRECT_IND",
+                        0x2: "ADV_NONCONN_IND (Non-connectable)",
+                        0x3: "SCAN_REQ",
+                        0x4: "SCAN_RSP",
+                        0x5: "CONNECT_REQ",
+                        0x6: "ADV_SCAN_IND (Scannable)",
+                        0x7: "ADV_EXT_IND"
+                    };
+                    return pdu_types[opts['value']] || "Unknown (" + opts['value'] + ")";
+                },
+                help: "BLE advertising PDU type indicating if device is connectable",
+            },
             ],
         });
     },

--- a/phy_btle.cc
+++ b/phy_btle.cc
@@ -366,6 +366,9 @@ int kis_btle_phy::common_classifier(CHAINCALL_PARMS) {
         new_dev = true;
     }
 
+    // Store the PDU type from the packet
+    btle_dev->set_pdu_type(btle_info->btle_decode->pdu_type());
+
     if (btle_info->btle_decode->is_txaddr_random())
         device->set_manuf(Globalreg::globalreg->manufdb->get_random_manuf());
 

--- a/phy_btle.h
+++ b/phy_btle.h
@@ -125,6 +125,7 @@ public:
    __Proxy(br_edr_unsupported, uint8_t, bool, bool, br_edr_unsupported);
    __Proxy(simultaneous_br_edr_controller, uint8_t, bool, bool, simultaneous_br_edr_controller);
    __Proxy(simultaneous_br_edr_host, uint8_t, bool, bool, simultaneous_br_edr_host);
+   __Proxy(pdu_type, uint8_t, uint8_t, uint8_t, pdu_type);
 
 protected:
     virtual void register_fields() override { 
@@ -141,6 +142,8 @@ protected:
                 &simultaneous_br_edr_controller);
         register_field("btle.device.simultaneous_br_edr_host", "BT LE simultaneous BR/EDR host mode",
                 &simultaneous_br_edr_host);
+        register_field("btle.device.pdu_type", "BTLE advertising PDU type",
+                &pdu_type);
     }
 
     std::shared_ptr<tracker_element_uint8> le_limited_discoverable;
@@ -148,6 +151,7 @@ protected:
     std::shared_ptr<tracker_element_uint8> br_edr_unsupported;
     std::shared_ptr<tracker_element_uint8> simultaneous_br_edr_controller;
     std::shared_ptr<tracker_element_uint8> simultaneous_br_edr_host;
+    std::shared_ptr<tracker_element_uint8> pdu_type;
 };
 
 class kis_btle_phy : public kis_phy_handler {


### PR DESCRIPTION
## Summary
Adds PDU type field to BTLE device tracker to enable filtering for connectable (ADV_IND) vs non-connectable (ADV_NONCONN_IND) devices.

## Changes
- Add `pdu_type` field to `btle_tracked_device` class in `phy_btle.h`
- Store PDU type during packet processing in `common_classifier()` function in `phy_btle.cc`
- Display PDU type in web UI with human-readable labels in `kismet.ui.btle.js`

## Background
The BLE parser (`bluetooth_parsers/btle.h`) already extracts PDU type information from packets, but it wasn't being stored in the device tracker. This change persists the PDU type so it's available via the REST API and can be used for filtering.

## Testing
- PDU type is stored correctly for different packet types
- Field is available via REST API as `btle.device.pdu_type`
- UI displays PDU type correctly
- Backward compatible (existing devices without PDU type handle gracefully)