### PR TITLE
for nrf 51822 datasource, change default baudrate to 460800, to match…

### DIFF
--- a/capture_nrf_51822/nrf_51822.h
+++ b/capture_nrf_51822/nrf_51822.h
@@ -66,7 +66,7 @@
 #define EVENT_PACKET_ADVERTISING 0x02
 #define EVENT_PACKET_DATA        0x06
 
-#define D_BAUDRATE B1000000
+#define D_BAUDRATE B460800
 
 #define _POSIX_SOURCE 1 /* POSIX compliant source */
 


### PR DESCRIPTION
… NordicRF

sniffer firmware default baud rate, as described here: https://cdn-learn.adafruit.com/downloads/pdf/introducing-the-adafruit-bluefruit-le-sniffer.pdf