### PR TITLE
fix use-after-free when using WS to connect remotely

### DIFF
--- a/capture_framework.c
+++ b/capture_framework.c
@@ -2484,6 +2484,7 @@ void ws_connect_attempt(kis_capture_handler_t *caph) {
         return;
     }
 
+    memset(&caph->lwsci, 0, sizeof(struct lws_client_connect_info));
     caph->lwsci.context = caph->lwscontext;
     caph->lwsci.port = caph->remote_port;
     caph->lwsci.address = caph->remote_host;


### PR DESCRIPTION
When connecting remotely via WebSockets, on OpenBSD, this ends in a segfault, because of a use after free.

Without the patch, running i.e. kismet_cap_sdr_rtladsb in gdb, it looks like:

```
egdb --args /usr/local/bin/kismet_cap_sdr_rtladsb --connect 127.0.0.1:2501 --source rtladsb:type=rtladsb --user buzz --password buzz 
GNU gdb (GDB) 16.3
Copyright (C) 2024 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-unknown-openbsd7.8".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from /usr/local/bin/kismet_cap_sdr_rtladsb...
(gdb) set follow-fork-mode child
(gdb) r
Starting program: /usr/local/bin/kismet_cap_sdr_rtladsb --connect 127.0.0.1:2501 --source rtladsb:type=rtladsb --user buzz --password buzz
capture_sdr_rtladsb_v2 main after cf_handler_set_userdata
capture_sdr_rtladsb_v2 main after cf_handler_set_open_cb
capture_sdr_rtladsb_v2 main after cf_handler_set_probe_cb
capture_sdr_rtladsb_v2 main after cf_handler_set_listdevices_cb
capture_sdr_rtladsb_v2 main after cf_handler_set_capture_cb
[Attaching after thread 241864 of process 3986 fork to child process 71581]
[New inferior 2 (process 71581)]
[Detaching after fork from parent process 3986]
[Inferior 1 (process 3986) detached]
[2026/01/15 16:38:05:3757] N: lws_create_context: LWS: 4.3.2-unknown, NET CLI SRV H1 H2 WS ConMon IPv6-absent
[2026/01/15 16:38:05:3763] N: __lws_lc_tag:  ++ [wsi|0|pipe] (1)
[2026/01/15 16:38:05:3765] N: __lws_lc_tag:  ++ [vh|0|default||-1] (1)
capture_sdr_rtladsb_v2 main after cf_handler_remote_capture
capture_sdr_rtladsb_v2 main after cf_jail_filesystem: 0
capture_sdr_rtladsb_v2 main after cf_drop_most_caps: 0
capture_framework: cf_handler_loop: caph->use_ws
capture_framework: cf_handler_loop: caph->use_ws and we actually have it!!
capture_sdr_rtladsb_v2: probe_callback: num_devices=1

Thread 2.1 received signal SIGSEGV, Segmentation fault.
[Switching to thread 225307 of process 71581]
0x00000be90e27527b in lws_vhost_bind_wsi (vh=0xdfdfdfdfdfdfdfdf, wsi=0xbe9c4eb3a00) at /home/ports/pobj/amd64/libwebsockets-4.3.2/libwebsockets-4.3.2/lib/core-net/wsi.c:80
80              vh->count_bound_wsi++;
(gdb) bt
#0  0x00000be90e27527b in lws_vhost_bind_wsi (vh=0xdfdfdfdfdfdfdfdf, wsi=0xbe9c4eb3a00) at /home/ports/pobj/amd64/libwebsockets-4.3.2/libwebsockets-4.3.2/lib/core-net/wsi.c:80
#1  0x00000be90e27b45a in lws_client_connect_via_info (i=0xbe9c4ef1670) at /home/ports/pobj/amd64/libwebsockets-4.3.2/libwebsockets-4.3.2/lib/core-net/client/connect.c:250
#2  0x00000be6f9d1648d in ws_connect_attempt (caph=0xbe9c4ef1600) at capture_framework.c:2503
#3  0x00000be6f9d1ae0c in ws_remotecap_broker (wsi=0x7398fb7f6698, reason=LWS_CALLBACK_PROTOCOL_INIT, user=0x0, in=0x0, len=0) at capture_framework.c:2523
#4  0x00000be90e26fe62 in lws_protocol_init_vhost (vh=0xbe9c4ec0380, any=0x7398fb7f6b9c) at /home/ports/pobj/amd64/libwebsockets-4.3.2/libwebsockets-4.3.2/lib/core-net/vhost.c:468
#5  0x00000be90e27003a in lws_protocol_init (context=0xbe8fd306000) at /home/ports/pobj/amd64/libwebsockets-4.3.2/libwebsockets-4.3.2/lib/core-net/vhost.c:517
#6  0x00000be90e259087 in lws_state_notify_protocol_init (mgr=0xbe8fd3065c8, link=0xbe8fd306610, current=7, target=8)
    at /home/ports/pobj/amd64/libwebsockets-4.3.2/libwebsockets-4.3.2/lib/core/context.c:227
#7  0x00000be90e27ab92 in _report (mgr=0xbe8fd3065c8, a=7, b=8) at /home/ports/pobj/amd64/libwebsockets-4.3.2/libwebsockets-4.3.2/lib/core-net/state.c:73
#8  0x00000be90e27aa4f in _lws_state_transition (mgr=0xbe8fd3065c8, target=8) at /home/ports/pobj/amd64/libwebsockets-4.3.2/libwebsockets-4.3.2/lib/core-net/state.c:98
#9  0x00000be90e27a9f5 in lws_state_transition_steps (mgr=0xbe8fd3065c8, target=12) at /home/ports/pobj/amd64/libwebsockets-4.3.2/libwebsockets-4.3.2/lib/core-net/state.c:136
#10 0x00000be90e2590f0 in lws_context_creation_completion_cb (sul=0xbe8fd3063f8) at /home/ports/pobj/amd64/libwebsockets-4.3.2/libwebsockets-4.3.2/lib/core/context.c:237
#11 0x00000be90e274d65 in __lws_sul_service_ripe (own=0xbe8fd306288, own_len=2, usnow=18921401430)
    at /home/ports/pobj/amd64/libwebsockets-4.3.2/libwebsockets-4.3.2/lib/core-net/sorted-usec-list.c:161
#12 0x00000be90e24dd83 in _lws_plat_service_tsi (context=0xbe8fd306000, timeout_ms=2000000000, tsi=0)
    at /home/ports/pobj/amd64/libwebsockets-4.3.2/libwebsockets-4.3.2/lib/plat/unix/unix-service.c:125
#13 0x00000be90e24e01e in lws_plat_service (context=0xbe8fd306000, timeout_ms=0) at /home/ports/pobj/amd64/libwebsockets-4.3.2/libwebsockets-4.3.2/lib/plat/unix/unix-service.c:235
#14 0x00000be90e2748fb in lws_service (context=0xbe8fd306000, timeout_ms=0) at /home/ports/pobj/amd64/libwebsockets-4.3.2/libwebsockets-4.3.2/lib/core-net/service.c:838
#15 0x00000be6f9d1761f in cf_handler_loop (caph=0xbe9c4ef1600) at capture_framework.c:3054
#16 0x00000be6f9d0e7ab in main (argc=9, argv=0x7398fb7fb758) at capture_sdr_rtladsb_v2.c:1026
(gdb) frame 3
#3  0x00000be6f9d1ae0c in ws_remotecap_broker (wsi=0x7398fb7f6698, reason=LWS_CALLBACK_PROTOCOL_INIT, user=0x0, in=0x0, len=0) at capture_framework.c:2523
2523                ws_connect_attempt(caph);
(gdb) p *caph
$1 = {capsource_type = 0xbe9c4eb9800 "rtladsb", remote_capable = 1, last_ping = 1768491485, seqno = 1, in_fd = -1, out_fd = -1, monitor_pid = 0, child_pid = -538976289, use_tcp = 0, 
  use_ipc = 0, use_ws = 1, remote_host = 0xbe9c4eba030 "127.0.0.1", remote_port = 2501, lwscontext = 0xbe8fd306000, lwsvhost = 0xbe9c4ec0380, lwsprotocol = 0xbe9c4ef07e0, 
  lwsring = 0xbe9c4edc8a0, lwstail = 0, lwsci = {context = 0xbe8fd306000, address = 0xbe9c4eba030 "127.0.0.1", port = 2501, ssl_connection = 0, 
    path = 0xbe9c4ebf340 "/datasource/remote/remotesource.ws?user=buzz&password=buzz", host = 0xbe9c4eba030 "127.0.0.1", origin = 0xbe9c4eba030 "127.0.0.1", 
    protocol = 0xbe6f9d040a3 "kismet-remote", ietf_version_or_minus_one = -538976289, userdata = 0xdfdfdfdfdfdfdfdf, client_exts = 0xdfdfdfdfdfdfdfdf, 
    method = 0xdfdfdfdfdfdfdfdf <error: Cannot access memory at address 0xdfdfdfdfdfdfdfdf>, parent_wsi = 0xdfdfdfdfdfdfdfdf, 
    uri_replace_from = 0xdfdfdfdfdfdfdfdf <error: Cannot access memory at address 0xdfdfdfdfdfdfdfdf>, 
    uri_replace_to = 0xdfdfdfdfdfdfdfdf <error: Cannot access memory at address 0xdfdfdfdfdfdfdfdf>, vhost = 0xdfdfdfdfdfdfdfdf, pwsi = 0xbe9c4ef1768, 
    iface = 0xdfdfdfdfdfdfdfdf <error: Cannot access memory at address 0xdfdfdfdfdfdfdfdf>, 
    local_protocol_name = 0xdfdfdfdfdfdfdfdf <error: Cannot access memory at address 0xdfdfdfdfdfdfdfdf>, 
    alpn = 0xdfdfdfdfdfdfdfdf <error: Cannot access memory at address 0xdfdfdfdfdfdfdfdf>, seq = 0xdfdfdfdfdfdfdfdf, opaque_user_data = 0xdfdfdfdfdfdfdfdf, 
    retry_and_idle_policy = 0xdfdfdfdfdfdfdfdf, manual_initial_tx_credit = -538976289, sys_tls_client_cert = 223 '\337', priority = 223 '\337', mqtt_cp = 0xdfdfdfdfdfdfdfdf, 
    fi_wsi_name = 0xdfdfdfdfdfdfdfdf <error: Cannot access memory at address 0xdfdfdfdfdfdfdfdf>, keep_warm_secs = 57311, log_cx = 0xdfdfdfdfdfdfdfdf, _unused = {0xdfdfdfdfdfdfdfdf, 
      0xdfdfdfdfdfdfdfdf, 0xdfdfdfdfdfdfdfdf, 0xdfdfdfdfdfdfdfdf}}, lwsclientwsi = 0x0, lwsestablished = 0, 
  lwsuri = 0xbe9c4ebf340 "/datasource/remote/remotesource.ws?user=buzz&password=buzz", lwsusessl = 0, lwssslcapath = 0x0, lwsinfo = {iface = 0x0, 
    protocols = 0xbe6f9d30380 <kismet_lws_protocols>, extensions = 0x0, token_limits = 0x0, http_proxy_address = 0x0, headers = 0x0, reject_service_keywords = 0x0, pvo = 0x0, 
    log_filepath = 0x0, mounts = 0x0, server_string = 0x0, error_document_404 = 0x0, port = -1, http_proxy_port = 0, max_http_header_data2 = 0, max_http_header_pool2 = 0, 
    keepalive_timeout = 0, http2_settings = {0, 0, 0, 0, 0, 0, 0}, max_http_header_data = 0, max_http_header_pool = 0, ssl_private_key_password = 0x0, ssl_cert_filepath = 0x0, 
    ssl_private_key_filepath = 0x0, ssl_ca_filepath = 0x0, ssl_cipher_list = 0x0, ecdh_curve = 0x0, tls1_3_plus_cipher_list = 0x0, server_ssl_cert_mem = 0x0, 
    server_ssl_private_key_mem = 0x0, server_ssl_ca_mem = 0x0, ssl_options_set = 0, ssl_options_clear = 0, simultaneous_ssl_restriction = 0, simultaneous_ssl_handshake_restriction = 0, 
    ssl_info_event_mask = 0, server_ssl_cert_mem_len = 0, server_ssl_private_key_mem_len = 0, server_ssl_ca_mem_len = 0, alpn = 0x0, client_ssl_private_key_password = 0x0, 
    client_ssl_cert_filepath = 0x0, client_ssl_cert_mem = 0x0, client_ssl_cert_mem_len = 0, client_ssl_private_key_filepath = 0x0, client_ssl_key_mem = 0x0, client_ssl_ca_filepath = 0x0, 
    client_ssl_ca_mem = 0x0, client_ssl_cipher_list = 0x0, client_tls_1_3_plus_cipher_list = 0x0, ssl_client_options_set = 0, ssl_client_options_clear = 0, client_ssl_ca_mem_len = 0, 
    client_ssl_key_mem_len = 0, provided_client_ssl_ctx = 0x0, ka_time = 0, ka_probes = 0, ka_interval = 0, timeout_secs = 0, connect_timeout_secs = 0, bind_iface = 0, 
    timeout_secs_ah_idle = 0, tls_session_timeout = 0, tls_session_cache_max = 0, gid = 0, uid = 0, options = 0, user = 0xbe9c4ef1600, count_threads = 0, fd_limit_per_thread = 10, 
    vhost_name = 0x0, external_baggage_free_on_destroy = 0x0, pt_serv_buf_size = 0, fops = 0x0, foreign_loops = 0x0, signal_cb = 0x0, pcontext = 0x0, finalize = 0x0, finalize_arg = 0x0, 
    listen_accept_role = 0x0, listen_accept_protocol = 0x0, pprotocols = 0x0, username = 0x0, groupname = 0x0, unix_socket_perms = 0x0, system_ops = 0x0, retry_and_idle_policy = 0x0, 
    register_notifier_list = 0x0, rlimit_nofile = 0, early_smd_cb = 0x0, early_smd_opaque = 0x0, early_smd_class_filter = 0, smd_ttl_us = 0, smd_queue_depth = 0, fo_listen_queue = 0, 
    event_lib_custom = 0x0, log_cx = 0x0, http_nsc_filepath = 0x0, http_nsc_heap_max_footprint = 0, http_nsc_heap_max_items = 0, http_nsc_heap_max_payload = 0, _unused = {0x0, 0x0}}, 
  lwsuuid = 0xbe9c4ed4450 "689C0913-0000-0000-0000-000080EF07D5", announced_uuid = 0x0, cli_sourcedef = 0xbe9c4edb5c0 "rtladsb:type=rtladsb", remote_retry = 1, daemonize = 0, tcp_fd = -1, 
  spindown = 0, in_ringbuf = 0x0, out_ringbuf = 0x0, ring = 0xdfdfdfdfdfdfdfdf, tail = 3755991007, out_ringbuf_lock = 0xbe9c4edc320, out_ringbuf_flush_cond = 0xbe9c4ed07c0, 
  out_ringbuf_flush_cond_mutex = 0xbe9c4ebda80, shutdown = 0, handler_lock = 0xbe9c4edb5e0, listdevices_cb = 0xbe6f9d0d110 <list_callback>, probe_cb = 0xbe6f9d0d230 <probe_callback>, 
  open_cb = 0xbe6f9d0d630 <open_callback>, chantranslate_cb = 0x0, chancontrol_cb = 0x0, chanfree_cb = 0x0, unknown_cb = 0x0, capture_cb = 0xbe6f9d0e360 <capture_thread>, 
  spectrumconfig_cb = 0x0, userdata = 0x7398fb7f7498, capture_running = 0, capturethread = 0xdfdfdfdfdfdfdfdf, signalthread = 0xdfdfdfdfdfdfdfdf, signal_running = 0, channel = 0x0, 
  hopping_running = 0, hopthread = 0xdfdfdfdfdfdfdfdf, channel_hop_list = 0x0, custom_channel_hop_list = 0x0, channel_hop_list_sz = 0, channel_hop_rate = -6.6776141455008222e+153, 
  max_channel_hop_rate = 0, channel_hop_failure_list = 0x0, channel_hop_failure_list_sz = 0, channel_hop_shuffle = 0, channel_hop_shuffle_spacing = 1, channel_hop_offset = -538976289, 
  gps_fixed_lat = 0, gps_fixed_lon = 0, gps_fixed_alt = 0, gps_name = 0x0, verbose = 1, ipc_list = 0x0}

All these 0xdfdfdfdfdfdfdfdf hinting to formerly freed memory. OpenBSD malloc, when using "J"unk, it will overwrite freed memory with 0xdfdfdfdf 
Other operating systems, there might still be a proper pointer to whereever, or just NULL, and the problem doesn't show up.


Therefore, as in the patch, properly memset caph->lwsci with 0x0.

With the patch, it happily establishes a WS connection.