### PR TITLE
rtl_433 do not unlock mutex twice

### DIFF
--- a/capture_sdr_rtl433_v2/capture_sdr_rtl433_v2.c
+++ b/capture_sdr_rtl433_v2/capture_sdr_rtl433_v2.c
@@ -488,8 +488,6 @@ void capture_thread(kis_capture_handler_t *caph) {
 
     wrap_cond_wait(&local433->rtl433_valid_cond,
             &local433->rtl433_valid_cond_mutex);
-    pthread_mutex_unlock(&local433->rtl433_valid_cond_mutex);
-
 }
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
very much the same as in rtladsb capture source. Here the wrapper blocks, until the double mutex is released, so not so easy to run into, but once it finishes, the mutex is released twice.