### PR TITLE
capture_wch_ble_analyzer_pro: handle negative libusb errors from wch_read_packets()

### DIFF
--- a/capture_wch_ble_analyzer_pro/capture_wch_ble_analyzer_pro.c
+++ b/capture_wch_ble_analyzer_pro/capture_wch_ble_analyzer_pro.c
@@ -613,12 +613,14 @@ static void on_packet(const wch_pkt_hdr_t *hdr, const uint8_t *pdu, int pdu_len,
 /* Run a standard glib mainloop inside the capture thread */
 void capture_thread(kis_capture_handler_t *caph) {
     local_wch_btle_t *local = (local_wch_btle_t *) caph->userdata;
+    char errstr[STATUS_MAX];
 
 #define DRAIN_POLL_MS  5
 #define IDLE_WAIT_MS   100
 
     while (1) {
         bool any_data = false;
+        bool any_open = false;
 
         if (caph->spindown) {
             break;
@@ -636,6 +638,15 @@ void capture_thread(kis_capture_handler_t *caph) {
                     continue;
                 }
 
+                if (n < 0) {
+                    snprintf(errstr, STATUS_MAX,
+                            "Unable to read from WCH radio %d %d:%d: %s, closing device",
+                            i, local->wch[i]->bus, local->wch[i]->addr,
+                            libusb_error_name(n));
+                    cf_send_message(caph, errstr, MSGFLAG_ERROR);
+                    wch_close_device(local->wch[i]);
+                }
+
                 break;
             }
         }
@@ -646,8 +657,30 @@ void capture_thread(kis_capture_handler_t *caph) {
             for (int i = 0; i < local->num_wch && !caph->spindown; i++) {
                 if (!local->wch[i]->is_open || !local->bufs[i])
                     continue;
-                wch_read_packets(local->wch[i], local->bufs[i], on_packet, caph, IDLE_WAIT_MS);
+
+                int n = wch_read_packets(local->wch[i], local->bufs[i], on_packet, caph, IDLE_WAIT_MS);
+
+                if (n < 0) {
+                    snprintf(errstr, STATUS_MAX,
+                            "Unable to read from WCH radio %d %d:%d: %s, closing device",
+                            i, local->wch[i]->bus, local->wch[i]->addr,
+                            libusb_error_name(n));
+                    cf_send_message(caph, errstr, MSGFLAG_ERROR);
+                    wch_close_device(local->wch[i]);
+                }
             }
+        }
+
+        /* If every configured MCU has failed and been closed, there is
+         * nothing left to capture from; stop looping so the handler spins
+         * down cleanly instead of busy-looping forever on a datasource
+         * that will never produce data again. */
+        for (int i = 0; i < local->num_wch; i++) {
+            any_open |= local->wch[i]->is_open;
+        }
+
+        if (!any_open) {
+            break;
         }
     }
 


### PR DESCRIPTION
`capture_thread()` in `capture_wch_ble_analyzer_pro.c` ignores negative
return values from `wch_read_packets()`.

`wch_read_packets()` returns the number of decoded packets (>= 0), or a
negative libusb error code for anything other than
`LIBUSB_ERROR_TIMEOUT` (which it already normalizes to 0, since that's
the expected "no data yet" case). `capture_thread()`'s Phase 1 drain
loop only branches on `n > 0` vs. "anything else", and Phase 2's
idle-wait call discards the return value entirely. So a real libusb
error - the MCU being unplugged (`LIBUSB_ERROR_NO_DEVICE`), an endpoint
stall (`LIBUSB_ERROR_IO`), etc. - is treated exactly like "no data right
now": the loop just keeps calling `wch_read_packets()` again forever,
spinning a CPU core, while the datasource stays marked as running in
the UI even though it can never produce data again. Re-enabling /
disabling the source from the web UI doesn't help either, since nothing
ever calls `wch_close_device()`.

This matches #610 ("wch ble analyzer pro stop working after a while" -
CPU pegged, source stuck showing as running, only a full kismet restart
recovers it).

The sibling `capture_radiacode/capture_radiacode_usb.c` driver already
has the right pattern for this framework: on a negative read result it
calls `cf_send_message(caph, errstr, MSGFLAG_ERROR)` and stops, letting
`cf_handler_spindown()` clean up.

This PR applies the same pattern here: when `wch_read_packets()` returns
`n < 0` in either phase, send an error message and call
`wch_close_device()` on that specific MCU (the driver supports up to
three MCUs aggregated into one source, so one failing shouldn't
necessarily kill the others). Once every configured MCU has failed and
been closed, the main loop breaks so the thread reaches
`cf_handler_spindown()` instead of looping forever.

Tested with a standalone harness that mirrors `capture_thread()`'s
control flow with a mocked `wch_read_packets()`: with the old logic, a
mock `LIBUSB_ERROR_NO_DEVICE` return causes the loop to keep calling
`wch_read_packets()` forever (never sends an error, never closes the
device). With the fix, the same input results in exactly one error
message, the device closed, and the thread proceeding to
`cf_handler_spindown()`.

I don't have this specific USB hardware, so this hasn't been exercised
against a real device - just the control-flow logic in isolation plus
a read-through of the actual libusb/kismet call sites involved.
