### PR TITLE
gps: clear gps_info_ok in packinfo reset, fix missing return in get_best_location

### DIFF
--- a/gpstracker.cc
+++ b/gpstracker.cc
@@ -499,8 +499,10 @@ std::shared_ptr<kis_gps_packinfo> gps_tracker::get_best_location() {
 void gps_tracker::get_best_location(kis_gps_packinfo& location) {
     kis_lock_guard<kis_mutex> lk(gpsmanager_mutex, "get_best_location");
 
-    if (gps_instances_vec == nullptr)
+    if (gps_instances_vec == nullptr) {
 		location.reset();
+		return;
+	}
 
     for (const auto& d : *gps_instances_vec) {
         auto gps = static_cast<kis_gps *>(d.get());

--- a/packet.h
+++ b/packet.h
@@ -189,6 +189,8 @@ public:
     }
 
     void reset() {
+        gps_info_ok = false;
+
         merge_partial = false;
         merge_flags = 0;
 


### PR DESCRIPTION
The refactor making gps a permanent packet component (38186dc0b) moved the gps_info_ok flag from kis_packet into kis_gps_packinfo, but the flag was never initialized in the constructor or cleared in reset().  Packets recycled through the packet pool kept a stale gps_info_ok=true with zeroed location data, causing handle_rx_packet and kis_gpspack_hook to skip attaching the live GPS fix - captures lost GPS once the pool started recycling packets.

Also add the missing return in gps_tracker::get_best_location(); the null gps_instances_vec guard fell through and dereferenced the null vector.

I noticed this because my kismet 2026.7 runs were "losing" gps all the time compared to 2026.3