### PR TITLE
packets: clear antenna_signal_map and content_checkum in layer1 packinfo reset

### DIFF
--- a/packet.h
+++ b/packet.h
@@ -260,6 +260,8 @@ public:
         freq_khz = 0;
         accuracy = 0;
         channel = "0";
+        antenna_signal_map.clear();
+        content_checkum = 0;
     }
 
     bool data_ok;


### PR DESCRIPTION
kis_layer1_packinfo::reset() did not clear the per-antenna signal map populated by the radiotap decoder, so packets recycled through the packet pool accumulated stale antenna signal entries from previous packets.  Also zero content_checkum.