### PR TITLE
datasource_sniffle_ble: filter packets that fail CRC validation

### DIFF
--- a/datasource_sniffle_ble.cc
+++ b/datasource_sniffle_ble.cc
@@ -156,6 +156,7 @@ int kis_datasource_sniffle_ble::handle_rx_data_content(kis_packet *packet,
     } else {
         packet->crc_ok = true;
         packet->checksum_valid = false;
+        packet->filtered = true;
     }
 
     auto decapchunk = packetchain->new_packet_component<kis_datachunk>();


### PR DESCRIPTION
Caught a bug; Set packet->filtered = true alongside checksum_valid = false in the CRC-invalid branch so invalid packets are now dropped before they can create or update a device.