### PR TITLE
datasource_nrf_51822: filter packets that fail CRC validation

### DIFF
--- a/datasource_nrf_51822.cc
+++ b/datasource_nrf_51822.cc
@@ -146,6 +146,14 @@ int kis_datasource_nrf51822::handle_rx_data_content(kis_packet *packet,
         decapchunk->dlt = KDLT_BLUETOOTH_LE_LL;
         decapchunk->set_data(packet->data.substr(sizeof(btle_rf), pkt_ctr));
         packet->insert(pack_comp_decap, decapchunk);
+    } else {
+        packet->crc_ok = true;
+        packet->checksum_valid = false;
+        packet->filtered = true;
+
+        // error, but preserve the packet for logging
+        packet->set_data((const char *) content, content_sz);
+        datachunk->set_data(packet->data);
     }
 
     return 1;


### PR DESCRIPTION
Add an else branch alongside the existing valid-packet handling to set packet->filtered = true when checksum_valid is false. Previously there was no such branch: invalid packets fell straight through with no packet data attached at all, likely the root cause of the sustained under-detection reported in [#399](https://github.com/kismetwireless/kismet/issues/399
); see the end of this conversation. This will allow for invalid packet counters to increment.