### PR TITLE
devicetracker: don't set peak location from packets without a GPS fix

### DIFF
--- a/devicetracker_component.cc
+++ b/devicetracker_component.cc
@@ -223,7 +223,7 @@ void kis_tracked_signal_data::append_signal(const kis_layer1_packinfo *lay1, con
                 if (max_signal->get() == 0 || max_signal->get() < lay1->signal_dbm) {
                     max_signal->set(lay1->signal_dbm);
 
-                    if (gps != nullptr) {
+                    if (gps != nullptr && gps->gps_info_ok) {
                         get_peak_loc()->set(gps->lat, gps->lon, gps->alt, gps->fix);
                     }
                 }
@@ -259,7 +259,7 @@ void kis_tracked_signal_data::append_signal(const kis_layer1_packinfo *lay1, con
                 if (max_signal->get() == 0 || max_signal->get() < lay1->signal_rssi) {
                     max_signal->set(lay1->signal_rssi);
 
-                    if (gps != nullptr) {
+                    if (gps != nullptr && gps->gps_info_ok) {
                         get_peak_loc()->set(gps->lat, gps->lon, gps->alt, gps->fix);
                     }
                 }


### PR DESCRIPTION
The refactor making gps a permanent packet component (38186dc0b) left kis_tracked_signal_data::append_signal guarding the peak location update with only a null check on the gps pointer.  Since devicetracker now passes &in_pack->gps_info unconditionally (update_common_device and inc_seenby_count), the pointer is never null and any packet that set a new max signal without a GPS fix overwrote peak_loc with a zeroed location at 0,0.

Require gps_info_ok in both the dbm and rssi branches, matching the gps_info_ok checks the refactor added elsewhere in devicetracker.