### PR TITLE
Avoid creating orphaned selectmenu elements when device view is not initialized

### DIFF
--- a/http_data/js/kismet.ui.js
+++ b/http_data/js/kismet.ui.js
@@ -54,6 +54,10 @@ exports.AddDeviceView = function(name, view, priority, group = 'none') {
 }
 
 exports.BuildDeviceViewSelector = function(element) {
+    // Avoid creating orphaned selectmenu elements when the target is missing
+    if (element.length === 0)
+        return;
+  
     var grouped_views = [];
 
     // Pre-sort the array so that as we build our nested stuff we do it in order


### PR DESCRIPTION
I noticed that when Kismet is reloaded while the "Devices" tab isn't active, the DOM grows over time, with a new `<div class="ui-selectmenu-menu ui-front"></div>` being added every 5 seconds.

Return early when `#device_view_holder` has not been initialized.

Reproduce:
- Open Kismet and select either the "Alerts" or "SSIDs" tab.
- Reload the page while one of those tabs is active.
- Observe the DOM.
- A new `<div class="ui-selectmenu-menu ui-front"></div>` is added every 5 seconds.