### PR TITLE
Fix typos

### DIFF
--- a/capture_framework.h
+++ b/capture_framework.h
@@ -800,10 +800,10 @@ void cf_cancel_packet(kis_capture_handler_t *caph,
 /* Commit a frame, this queues the frame for transmission and
  * unlocks the capture framework.
  *
- * The final length of the content is updated in the protoco frame
+ * The final length of the content is updated in the protocol frame
  * before transmission.
  *
- * At the end of queing, the meta data is freed and is no longer
+ * At the end of queueing, the meta data is freed and is no longer
  * valid for use.
  *
  * Returns:

--- a/capture_linux_wifi/linux_wireless_control.h
+++ b/capture_linux_wifi/linux_wireless_control.h
@@ -26,7 +26,7 @@
 #include <stdio.h>
 #include <unistd.h>
 
-/* We need thes defs regardless if we have wext */
+/* We need these defs regardless if we have wext */
 
 /* Wireless extensions monitor mode number */
 #define LINUX_WLEXT_MONITOR 6

--- a/capture_radiacode/capture_radiacode_usb.c
+++ b/capture_radiacode/capture_radiacode_usb.c
@@ -199,7 +199,7 @@ char *radiacode_transport_execute(radiacode_comms_t *comms,
 
         trials = 0
         max_trials = 3
-        while trials < max_trials:  # repeat until non-zero lenght data received
+        while trials < max_trials:  # repeat until non-zero length data received
             data = self._device.read(0x81, 256, timeout=self._timeout_ms).tobytes()
             if len(data) != 0:
                 break
@@ -487,7 +487,7 @@ int open_usb_device(kis_capture_handler_t *caph, char *errstr) {
     }
 
 	/* It appears the radiacode needs to sink all pending io on open before
-	 * issueing commands, spin burning data until we time out */
+	 * issuing commands, spin burning data until we time out */
 	while (1) {
 		r = libusb_bulk_transfer(localrad->usb_handle, 0x81,
 				(unsigned char *) sinkbuf, 256, &sink_len, 500);

--- a/capture_sdr_rtlamr/KismetCaptureRtlamr/__init__.py
+++ b/capture_sdr_rtlamr/KismetCaptureRtlamr/__init__.py
@@ -500,7 +500,7 @@ class KismetRtlamr(object):
         # Quantize
         bits = np.where(r > 0, 1, 0)
 
-        # Fake decimation of the bits themselves after the quanitization
+        # Fake decimation of the bits themselves after the quantization
         bits = bits[::self.decimation]
 
         return bits

--- a/conf/kismet.conf
+++ b/conf/kismet.conf
@@ -213,7 +213,7 @@ override_remote_timestamp=true
 
 
 # Do we allow plugins to be used?  This will load plugins from the system
-# and user plugin directiories when set to true.
+# and user plugin directories when set to true.
 allowplugins=true
 
 

--- a/conf/kismet_alerts.conf
+++ b/conf/kismet_alerts.conf
@@ -136,7 +136,7 @@ alert=DHCPCLIENTID,5/min,1/sec
 alert=DHCPCONFLICT,10/min,1/sec
 alert=DISASSOCTRAFFIC,10/min,1/sec
 
-# Deprecated; similarly to deauthcodeinvalid doesn't seem meaninful
+# Deprecated; similarly to deauthcodeinvalid doesn't seem meaningful
 # with modern managed APs
 alert=DISCONCODEINVALID,0/min,0/sec
 

--- a/config.h.in
+++ b/config.h.in
@@ -150,7 +150,7 @@
 /* Netlink works */
 #undef HAVE_LINUX_NETLINK
 
-/* Linux wireless extentions present */
+/* Linux wireless extensions present */
 #undef HAVE_LINUX_WIRELESS
 
 /* local radiotap packet headers */

--- a/configure.ac
+++ b/configure.ac
@@ -893,7 +893,7 @@ if test "$wantwext" = "yes"; then
 	fi # wexth
 
 	AC_MSG_RESULT(yes)
-	AC_DEFINE(HAVE_LINUX_WIRELESS, 1, Linux wireless extentions present)
+	AC_DEFINE(HAVE_LINUX_WIRELESS, 1, Linux wireless extensions present)
 	linux_wireless="yes";
 
 	if test "$linux_wireless" = "yes"; then
@@ -1054,7 +1054,7 @@ if test "$caponly"x = "no"x; then
     # AC_CHECK_LIB([tbb], [main], CXXLIBS="$CXXLIBS -ltbb")
 fi
 
-# Dont' check pcre if we're only building datasources
+# Don't check pcre if we're only building datasources
 if test "$caponly"x = "no"x; then
     if test "$wantpcre" = "yes"; then
         # Check for pcre2 first

--- a/devicetracker_view.cc
+++ b/devicetracker_view.cc
@@ -617,7 +617,7 @@ void device_tracker_view::device_endpoint_handler(std::shared_ptr<kis_net_beast_
             transmit = wrapper_elem;
         }
 
-        // Handle legacy datatable otpions, if datatable=true
+        // Handle legacy datatable options, if datatable=true
         if (con->json().value("datatable", false)) {
             // Extract from the raw postvars
             auto start_k = con->http_variables().find("start");

--- a/devicetracker_view_workers.h
+++ b/devicetracker_view_workers.h
@@ -101,7 +101,7 @@ public:
 #endif
     };
 
-    // Filter baed on a prepared vector
+    // Filter based on a prepared vector
     device_tracker_view_regex_worker(const std::vector<std::shared_ptr<device_tracker_view_regex_worker::pcre_filter>>& filter_vec);
 
     // Build a PCRE from a standard regex description on a POST.
@@ -131,7 +131,7 @@ protected:
 // Searches multiple fields for a given string
 class device_tracker_view_stringmatch_worker : public device_tracker_view_worker {
 public:
-    // Match a given string against a list of resovled field paths
+    // Match a given string against a list of resolved field paths
     device_tracker_view_stringmatch_worker(const std::string& in_query,
             const std::vector<std::vector<int>>& in_paths);
     device_tracker_view_stringmatch_worker(const device_tracker_view_stringmatch_worker& w) {
@@ -158,7 +158,7 @@ protected:
 // Searches multiple fields for a given string
 class device_tracker_view_icasestringmatch_worker : public device_tracker_view_worker {
 public:
-    // Match a given string against a list of resovled field paths
+    // Match a given string against a list of resolved field paths
     device_tracker_view_icasestringmatch_worker(const std::string& in_query,
             const std::vector<std::vector<int>>& in_paths);
     device_tracker_view_icasestringmatch_worker(const device_tracker_view_icasestringmatch_worker& w) {

--- a/fnv_ht.h
+++ b/fnv_ht.h
@@ -27,7 +27,7 @@
 // as the key and returns a pointer to the cached string.  We never
 // expire cache.
 //
-// fnv_ht uses raw pointers to try to opimize string cache for things 
+// fnv_ht uses raw pointers to try to optimize string cache for things 
 // in Kismet like the SSID and encryption strings; using smart pointers
 // means another 8 bytes lost per emtry.
 //

--- a/globalregistry.h
+++ b/globalregistry.h
@@ -278,7 +278,7 @@ public:
     std::atomic<unsigned int> streambuf_circulation;
 
     kis_mutex ext_mutex;
-    // Exernal global references, string to intid
+    // External global references, string to intid
     std::map<std::string, int> ext_name_map;
     // External globals
     std::map<int, std::shared_ptr<void> > ext_data_map;

--- a/gpstracker.h
+++ b/gpstracker.h
@@ -76,7 +76,7 @@ public:
 
     virtual void trigger_deferred_startup() override;
 
-    // Register a gps builer prototype
+    // Register a gps builder prototype
     void register_gps_builder(shared_gps_builder in_builder);
 
     // Create a GPS from a definition string

--- a/kis_databaselogfile.h
+++ b/kis_databaselogfile.h
@@ -179,7 +179,7 @@ protected:
     int packet_handler_id;
 
     // Keep track of our commit cycles; to avoid thrashing the filesystem with
-    // commit state we run a 10 second tranasction commit loop
+    // commit state we run a 10 second transaction commit loop
     kis_mutex transaction_mutex;
     int transaction_timer;
 

--- a/kis_datasource.cc
+++ b/kis_datasource.cc
@@ -1846,7 +1846,7 @@ void kis_datasource::handle_packet_opensource_report_v3(uint32_t seqno, uint16_t
     // merge the custom channels list and the supplied channels list.  Otherwise,
     // copy the source list to the hop list.
     //
-    // if we have a 'channel=' in the source definition that isnt in the list, add it.
+    // if we have a 'channel=' in the source definition that isn't in the list, add it.
     //
     // if we havce an 'add_channels=' in the source, use the provided list + the
     // added list as the hop list

--- a/kis_datasource.h
+++ b/kis_datasource.h
@@ -659,7 +659,7 @@ protected:
 
     virtual void handle_msg_proxy(const std::string& msg, const int type) override;
 
-    // specific decoders to break out signal and gps extraction for derivitive classes; to be passed the
+    // specific decoders to break out signal and gps extraction for derivative classes; to be passed the
     // decoded packet mpack tree.  most child classes shouldn't ever need to touch this since it also
     // implies handling the whole raw packet.
     virtual bool handle_sub_gps(mpack_node_t& root,
@@ -695,7 +695,7 @@ protected:
     virtual unsigned int send_probe_source_v2(std::string in_defintion, unsigned int in_transaction,
             probe_callback_t in_cb);
 
-    // specific decoders broken out for derivitive classes to access signal and gps easily
+    // specific decoders broken out for derivative classes to access signal and gps easily
     virtual bool handle_sub_gps(KismetDatasource::SubGps in_gps, kis_gps_packinfo& gpsinfo);
     bool handle_sub_signal(KismetDatasource::SubSignal in_signal, kis_layer1_packinfo& siginfo);
 #endif

--- a/kis_external_packet.h
+++ b/kis_external_packet.h
@@ -148,7 +148,7 @@ typedef struct kismet_external_frame_v3 {
  *
  * v3 sub-blocks
  *
- *    Some fields are defined as sub-blocks; a sub block is serialzied as
+ *    Some fields are defined as sub-blocks; a sub block is serialized as
  *    a msgpack map of integer field IDs to msgpack values.
  *
  *    Sub-block field IDs are determined by the sub-block type.
@@ -461,7 +461,7 @@ typedef struct kismet_external_frame_v3 {
 #define KIS_EXTERNAL_V3_KDS_PROBEREPORT_FIELD_SEQNO             1
 /* interface sub-block */
 #define KIS_EXTERNAL_V3_KDS_PROBEREPORT_FIELD_INTERFACE         2
-/* stirng */
+/* string */
 #define KIS_EXTERNAL_V3_KDS_PROBEREPORT_FIELD_MSG               3
 
 

--- a/kis_ppilogfile.cc
+++ b/kis_ppilogfile.cc
@@ -238,7 +238,7 @@ int kis_ppi_logfile::packet_handler(CHAINCALL_PARMS) {
             gps_tagsize += 12; // lon, lat, appid,
         if (in_pack->gps_info.fix >= 3)
             gps_tagsize +=4; // altitude
-        //Could eventually include hdop, vdop using simillar scheme here
+        //Could eventually include hdop, vdop using similar scheme here
     }
     /* although dot11common tags are constant size, we follow the same pattern here*/
     if (in_pack->signal_info.data_ok) {

--- a/kis_wiglecsvlogfile.cc
+++ b/kis_wiglecsvlogfile.cc
@@ -321,7 +321,7 @@ int kis_wiglecsv_logfile::packet_handler(CHAINCALL_PARMS) {
                 dev->get_frequency(),
                 signal,
                 in_pack->gps_info.lat, in_pack->gps_info.lon, in_pack->gps_info.alt,
-                0, // TODO - dereive a gps accuracy
+                0, // TODO - derive a gps accuracy
                 "WIFI");
 
     } else if (wigle->bt_phy->device_is_a(dev)) {

--- a/log_tools/kismetdb_to_wiglecsv.cc
+++ b/log_tools/kismetdb_to_wiglecsv.cc
@@ -795,7 +795,7 @@ int main(int argc, char *argv[]) {
                 frequency / 1000,
                 signal,
                 lat, lon, alt,
-                0, // TODO - dereive a gps accuracy
+                0, // TODO - derive a gps accuracy
                 "WIFI");
 
         n_saved++;

--- a/messagebus.h
+++ b/messagebus.h
@@ -191,7 +191,7 @@ public:
             fflush(stderr);
         }
 
-        // Don't propogate debug messages into the eventbus or silly things can happen
+        // Don't propagate debug messages into the eventbus or silly things can happen
         if (flags & MSGFLAG_DEBUG) {
             fprintf(stdout, "DEBUG: %s\n", msg.c_str());
             fflush(stdout);

--- a/packaging/systemd/README
+++ b/packaging/systemd/README
@@ -17,7 +17,7 @@ Kismet Service (and Debug Service)
     By default, the Kismet systemd service runs Kismet as root; this is NOT best practices
     but it is the only user consistently available.
 
-    It is STONGLY recommended that you install Kismet as suid-root via `make suidinstall`,
+    It is STRONGLY recommended that you install Kismet as suid-root via `make suidinstall`,
     and that you run Kismet as a non-privileged user.  Kismet will then limit root 
     access to the capture binaries which control individual interfaces.
 

--- a/packaging/systemd/debug/README
+++ b/packaging/systemd/debug/README
@@ -24,7 +24,7 @@ Kismet Debug Service
     By default, the Kismet systemd service runs Kismet as root; this is NOT best practices
     but it is the only user consistently available.
 
-    It is STONGLY recommended that you install Kismet as suid-root via `make suidinstall`,
+    It is STRONGLY recommended that you install Kismet as suid-root via `make suidinstall`,
     and that you run Kismet as a non-privileged user.  Kismet will then limit root 
     access to the capture binaries which control individual interfaces.
 

--- a/phy_80211.cc
+++ b/phy_80211.cc
@@ -2976,7 +2976,7 @@ void kis_80211_phy::handle_ssid_s1g(const std::shared_ptr<kis_tracked_device_bas
 
         }
 
-        // xxhash32 says hashes are canoically represented as little-endian
+        // xxhash32 says hashes are canonically represented as little-endian
         dot11dev->set_beacon_fingerprint(htole32(tag_hash.hash()));
 
         ssid->inc_beacons_sec();
@@ -3485,7 +3485,7 @@ void kis_80211_phy::handle_ssid(const std::shared_ptr<kis_tracked_device_base>& 
 
         }
 
-        // xxhash32 says hashes are canoically represented as little-endian
+        // xxhash32 says hashes are canonically represented as little-endian
         dot11dev->set_beacon_fingerprint(htole32(tag_hash.hash()));
 
         ssid->inc_beacons_sec();

--- a/phy_80211.h
+++ b/phy_80211.h
@@ -543,7 +543,7 @@ protected:
             const std::shared_ptr<kis_packet>& in_pack,
             const std::shared_ptr<dot11_packinfo>& dot11info);
 
-    // Map a device as a client of an acceess point, fill in any data in the
+    // Map a device as a client of an access point, fill in any data in the
     // per-client records
     void process_client(const std::shared_ptr<kis_tracked_device_base>& bssiddev,
             const std::shared_ptr<dot11_tracked_device>& bssiddot11,

--- a/phy_80211_dissectors.cc
+++ b/phy_80211_dissectors.cc
@@ -2431,7 +2431,7 @@ int kis_80211_phy::packet_dot11_ie_dissector(kis_packet* in_pack, dot11_packinfo
                                             // Affected code in rtlwifi:
                                             // noa_num = (noa_len - 2) / 13;
                                             // if (noa_num > P2P_MAX_NOA_NUM)
-                                            // and P2P_MAX_NOA_NUM is 2, therefor:
+                                            // and P2P_MAX_NOA_NUM is 2, therefore:
                                             if (wfa_ie_tag->tag_len() > 28) {
                                                 alertracker->raise_alert(alert_rtlwifi_p2p_ref, in_pack,
                                                         packinfo->bssid_mac, packinfo->source_mac,

--- a/plugin-demo-externalhttp/kismet_proxytest
+++ b/plugin-demo-externalhttp/kismet_proxytest
@@ -79,7 +79,7 @@ class KismetProxyTest(object):
         # Print a static response
         externalhandler.send_http_response(request.req_id, bytes("<html><body><b>This is from python!</b></body></html>", "UTF-8"))
 
-    # Callback function for handling a req of our variabls.html endpoint
+    # Callback function for handling a req of our variables.html endpoint
     def handle_web_python_get(self, externalhandler, request):
         print("PYTHON - Handle web req {} {} {}".format(request.req_id, request.method, request.uri))
         print("PYTHON - GET variables ")
@@ -88,7 +88,7 @@ class KismetProxyTest(object):
 
         externalhandler.send_http_response(request.req_id, bytes("<html><body><b>This is from python!</b></body></html>", "UTF-8"))
 
-    # Callback function for handling a req of our variabls.html endpoint
+    # Callback function for handling a req of our variables.html endpoint
     def handle_web_python_post(self, externalhandler, request):
         print("PYTHON - Handle web req {} {} {}".format(request.req_id, request.method, request.uri))
         for i in request.variable_data:

--- a/protobuf_definitions/eventbus.proto
+++ b/protobuf_definitions/eventbus.proto
@@ -22,7 +22,7 @@ message EventbusRegisterListener {
     repeated string event = 1;
 }
 
-// Publish an event; remotely pubished events must not overlap internal events and must be
+// Publish an event; remotely published events must not overlap internal events and must be
 // limited to pure-json data; the content of a remote published event will not be translated
 // to a complex C++ object.
 // event_content_json will be published in the kismet event as event_content["kismet.eventbus.event_json"]

--- a/trackedcomponent.h
+++ b/trackedcomponent.h
@@ -290,7 +290,7 @@ class tracker_component : public tracker_element_map {
     }
 
 // Proxy, connected to a dynamic element.  Getting or setting the dynamic element
-// creates it.  The lamda function is called after setting.
+// creates it.  The lambda function is called after setting.
 #define __ProxyDynamicL(name, ptype, itype, rtype, cvar, id, lambda) \
     inline shared_tracker_element get_tracker_##name() { \
         if (cvar == nullptr) { \

--- a/trackedelement.h
+++ b/trackedelement.h
@@ -391,7 +391,7 @@ constexpr17 C tracker_element_clone_adaptor(C p) {
     // return std::static_pointer_cast<c_t>(std::shared_ptr<tracker_element>(std::move(p->clone_type())));
 }
 
-// Aliased element used to link one element to anothers name, for instance to
+// Aliased element used to link one element to another's name, for instance to
 // allow the dot11 tracker a way to link the most recently used ssid from the
 // map to a custom field
 class tracker_element_alias : public tracker_element {


### PR DESCRIPTION
Fixes misspelled words in code comments and docs. No code or user-facing strings changed.