### PR TITLE
Fix v3 GPS clobbering and restore IE 192 VHT operation parsing

### DIFF
--- a/kis_datasource.cc
+++ b/kis_datasource.cc
@@ -2259,7 +2259,7 @@ void kis_datasource::handle_packet_data_report_v3(uint32_t in_seqno, uint16_t co
 
     if (suppress_gps && !packet->gps_info.gps_info_ok) {
         packet->suppress_gps = true;
-    } else if (device_gps != nullptr) {
+    } else if (!packet->gps_info.gps_info_ok && device_gps != nullptr) {
         auto gpsinfo = device_gps->get_location();
 
         if (gpsinfo != nullptr) {

--- a/phy_80211_dissectors.cc
+++ b/phy_80211_dissectors.cc
@@ -2216,6 +2216,13 @@ int kis_80211_phy::packet_dot11_ie_dissector(kis_packet* in_pack, dot11_packinfo
 
                 break;
 
+            case 192:
+                try {
+                    packinfo->dot11vht.parse(ie_tag.tag_data());
+                } catch (...) { }
+
+                break;
+
             case 214:
                 try {
                     dot11_ie_214_short_beacon_interval sbi_tag;


### PR DESCRIPTION
Two regressions on current master.

**v3 report GPS clobbered by per-source GPS** (`kis_datasource.cc`)

`handle_packet_data_report_v3()` applies the per-source `gps=` location whenever `device_gps` is set, overwriting a location the capture source already supplied in its own GPS block. The arms stopped being mutually exclusive in 38186dc0b; the v2 path and `datasource_linux_bluetooth` still fall back to `device_gps` only when the report carries no GPS. The wrong coordinates propagate to device locations, kismetdb, wiglecsv and pcapng.

**IE 192 (VHT Operation) no longer parsed** (`phy_80211_dissectors.cc`)

The switch conversion in 36870349b dropped the tag 192 handler. `dot11_ie_192_vht_op.h` is still included, but `packinfo->dot11vht` is never parsed, so the `dot11vht.parsed()` branch in `phy_80211.cc` never runs and VHT channel width, `ht_center_1` and `ht_center_2` are never set on 802.11ac SSIDs.

Both files compile clean.